### PR TITLE
refactor: better styled output using anstyle crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/heabijay/crtcli"
 license = "MIT"
 
 [dependencies]
+anstyle = "1.0.10"
 anstream = "0.6.18"
 bincode = "1.3.3"
 clap = { version = "4.5.23", features = ["derive", "env", "suggestions", "usage"] }
@@ -15,7 +16,6 @@ clap_complete = "4.5.40"
 dotenvy = "0.15.7"
 flate2 = "1.0.35"
 hyper-util = "0.1.10"
-owo-colors = "4.1.0"
 quick-xml = "0.37.2"
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"] }
@@ -33,6 +33,9 @@ features = ["charset", "blocking", "http2", "macos-system-configuration", "json"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+
+[profile.dev]
+debug = false # Disable debug symbol to speedup dev compilation
 
 [profile.release]
 lto = true

--- a/src/app/app_installer.rs
+++ b/src/app/app_installer.rs
@@ -1,7 +1,7 @@
 use crate::app::client::{CrtClient, CrtClientGenericError};
 use crate::app::{CrtRequestBuilderReauthorize, StandardServiceError, StandardServiceResponse};
 use reqwest::Method;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 pub struct AppInstallerService<'c>(&'c CrtClient);
@@ -73,10 +73,14 @@ impl<'c> AppInstallerService<'c> {
         Ok(())
     }
 
-    pub fn load_packages_to_db(
+    pub fn load_packages_to_db<StrArr, Str>(
         &self,
-        package_names: Option<&[&str]>,
-    ) -> Result<FileSystemSynchronizationResultResponse, CrtClientGenericError> {
+        package_names: Option<StrArr>,
+    ) -> Result<FileSystemSynchronizationResultResponse, CrtClientGenericError>
+    where
+        Str: AsRef<str>,
+        StrArr: AsRef<[Str]> + Serialize,
+    {
         let response = self
             .0
             .request(
@@ -92,10 +96,14 @@ impl<'c> AppInstallerService<'c> {
             .into_result()?)
     }
 
-    pub fn load_packages_to_fs(
+    pub fn load_packages_to_fs<StrArr, Str>(
         &self,
-        package_names: Option<&[&str]>,
-    ) -> Result<FileSystemSynchronizationResultResponse, CrtClientGenericError> {
+        package_names: Option<StrArr>,
+    ) -> Result<FileSystemSynchronizationResultResponse, CrtClientGenericError>
+    where
+        Str: AsRef<str>,
+        StrArr: AsRef<[Str]> + Serialize,
+    {
         let response = self
             .0
             .request(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,8 +9,7 @@ pub use session::*;
 mod credentials;
 pub use credentials::*;
 
-mod workspace_explorer;
-pub use workspace_explorer::BuildResponse;
+pub mod workspace_explorer;
 
 mod package_installer;
 pub use app_installer::{

--- a/src/app/workspace_explorer.rs
+++ b/src/app/workspace_explorer.rs
@@ -137,28 +137,8 @@ pub struct BuildPackageErrorInfo {
     pub message: String,
 }
 
-impl Display for BuildPackageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let prefix = match self.warning {
-            true => "WARN",
-            false => "ERROR",
-        };
-
-        let filename_substr = match self.filename.as_str() {
-            "" => "",
-            _ => &format!(" {}({}:{}):", self.filename, self.line, self.column),
-        };
-
-        write!(
-            f,
-            "{}{} {}: {}",
-            prefix, filename_substr, self.error_number, self.error_text
-        )
-    }
-}
-
 #[derive(Deserialize, Debug)]
-pub struct GetPackagesResponse {
+struct GetPackagesResponse {
     packages: Vec<GetPackagesResponseItem>,
 }
 

--- a/src/cmd/app/compile.rs
+++ b/src/cmd/app/compile.rs
@@ -1,8 +1,12 @@
-use crate::app::{BuildResponse, CrtClientGenericError};
+use crate::app::workspace_explorer::{BuildPackageError, BuildResponse};
+use crate::app::CrtClientGenericError;
+use crate::cmd::app::restart::print_app_restart_requested;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
+use anstream::stdout;
+use anstyle::{AnsiColor, Color, Style};
 use clap::Args;
-use owo_colors::OwoColorize;
 use std::error::Error;
+use std::io::Write;
 use thiserror::Error;
 
 #[derive(Args, Debug)]
@@ -39,11 +43,7 @@ impl AppCommand for CompileCommand {
                 .restart_app()
                 .map_err(CompileCommandError::AppRestart)?;
 
-            eprintln!("Application restart has been requested");
-
-            if !client.is_net_framework() {
-                eprintln!("Note: if restart does not work, please check if you need to use --net-framework flag");
-            }
+            print_app_restart_requested(&client);
         }
 
         Ok(())
@@ -51,18 +51,36 @@ impl AppCommand for CompileCommand {
 }
 
 pub fn print_build_response(response: &BuildResponse) -> Result<(), Box<dyn Error>> {
+    let warn_printer = BuildPackageErrorPrinter::new_for_warning();
+    let error_printer = BuildPackageErrorPrinter::new_for_error();
+
+    let mut stdout = stdout().lock();
+
     if let Some(errors) = &response.errors {
         for error in errors {
-            println!("{error}");
+            match error.warning {
+                true => warn_printer.print(&mut stdout, error),
+                false => error_printer.print(&mut stdout, error),
+            }
         }
+
+        writeln!(stdout).unwrap();
     }
 
     if let Some(error_info) = &response.error_info {
-        println!("{}", error_info.message)
+        writeln!(
+            stdout,
+            "{style}Error message -> {}{style:#}",
+            error_info.message,
+            style = error_printer.error_style
+        )
+        .unwrap();
+
+        writeln!(stdout).unwrap();
     }
 
     if let Some(message) = &response.message {
-        println!("--> {message}")
+        writeln!(stdout, "-> {message}").unwrap();
     }
 
     match (
@@ -72,10 +90,66 @@ pub fn print_build_response(response: &BuildResponse) -> Result<(), Box<dyn Erro
     ) {
         (true, _, _) => {}
         (false, false, None) => {}
-        _ => return Err("compile was finished with errors".into()),
+        _ => return Err("compilation finished with errors".into()),
     }
 
-    eprintln!("{}", "Compiled successfully!".green());
+    eprintln!(
+        "{style}Compilation completed successfully!{style:#}",
+        style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)))
+    );
 
     Ok(())
+}
+
+struct BuildPackageErrorPrinter {
+    type_style: Style,
+    file_style: Style,
+    error_style: Style,
+}
+
+impl BuildPackageErrorPrinter {
+    fn new_for_warning() -> Self {
+        Self::new_from_style(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow))))
+    }
+
+    fn new_for_error() -> Self {
+        Self::new_from_style(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red))))
+    }
+
+    fn new_from_style(base_style: Style) -> Self {
+        Self {
+            type_style: base_style.bold(),
+            file_style: base_style.italic(),
+            error_style: base_style,
+        }
+    }
+
+    fn print(&self, mut w: impl Write, e: &BuildPackageError) {
+        match e.warning {
+            true => write!(w, "{style}WARN{style:#}", style = self.type_style).unwrap(),
+            false => write!(w, "{style}ERROR{style:#}", style = self.type_style).unwrap(),
+        };
+
+        match e.filename.as_str() {
+            "" => (),
+            _ => write!(
+                w,
+                " {style}{}({}:{}){style:#}",
+                e.filename,
+                e.line,
+                e.column,
+                style = self.file_style
+            )
+            .unwrap(),
+        };
+
+        writeln!(
+            w,
+            " {style}{}: {}{style:#}",
+            e.error_number,
+            e.error_text,
+            style = self.error_style
+        )
+        .unwrap();
+    }
 }

--- a/src/cmd/app/fs/check_fs.rs
+++ b/src/cmd/app/fs/check_fs.rs
@@ -1,7 +1,9 @@
 use crate::cmd::app::{AppCommand, AppCommandArgs};
+use anstream::stdout;
+use anstyle::{AnsiColor, Color, Style};
 use clap::Args;
-use owo_colors::OwoColorize;
 use std::error::Error;
+use std::io::Write;
 
 #[derive(Args, Debug)]
 pub struct CheckFsCommand;
@@ -13,13 +15,24 @@ impl AppCommand for CheckFsCommand {
             .workspace_explorer_service()
             .get_is_file_system_development_mode()?;
 
-        eprintln!(
-            "File System Development mode (FSD): {}",
-            match result {
-                true => "Enabled".green().to_string(),
-                false => "Disabled".red().to_string(),
-            }
-        );
+        let mut stdout = stdout().lock();
+
+        write!(stdout, "File System Development mode (FSD): ").unwrap();
+
+        match result {
+            true => writeln!(
+                stdout,
+                "{style}Enabled{style:#}",
+                style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)))
+            )
+            .unwrap(),
+            false => writeln!(
+                stdout,
+                "{style}Disabled{style:#}",
+                style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)))
+            )
+            .unwrap(),
+        }
 
         Ok(())
     }

--- a/src/cmd/app/fs/pull_fs.rs
+++ b/src/cmd/app/fs/pull_fs.rs
@@ -15,12 +15,7 @@ impl AppCommand for PullFsCommand {
         let result = app
             .build_client()?
             .app_installer_service()
-            .load_packages_to_fs(
-                self.packages
-                    .as_ref()
-                    .map(|vec| vec.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-                    .as_deref(),
-            )?;
+            .load_packages_to_fs(self.packages.as_ref())?;
 
         print_fs_sync_result(&result);
 

--- a/src/cmd/app/fs/push_fs.rs
+++ b/src/cmd/app/fs/push_fs.rs
@@ -15,12 +15,7 @@ impl AppCommand for PushFsCommand {
         let result = app
             .build_client()?
             .app_installer_service()
-            .load_packages_to_db(
-                self.packages
-                    .as_ref()
-                    .map(|vec| vec.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-                    .as_deref(),
-            )?;
+            .load_packages_to_db(self.packages.as_ref())?;
 
         print_fs_sync_result(&result);
 

--- a/src/cmd/app/pkg/compile_pkg.rs
+++ b/src/cmd/app/pkg/compile_pkg.rs
@@ -1,4 +1,5 @@
 use crate::app::CrtClientGenericError;
+use crate::cmd::app::restart::print_app_restart_requested;
 use crate::cmd::app::{print_build_response, AppCommand, AppCommandArgs};
 use clap::Args;
 use std::error::Error;
@@ -38,11 +39,7 @@ impl AppCommand for CompilePkgCommand {
                 .restart_app()
                 .map_err(CompilePkgCommandError::AppRestart)?;
 
-            eprintln!("Application restart has been requested");
-
-            if !client.is_net_framework() {
-                eprintln!("Note: if restart does not work, please check if you need to use --net-framework flag");
-            }
+            print_app_restart_requested(&client);
         }
 
         Ok(())

--- a/src/cmd/app/pkg/fs/pull_pkg_fs.rs
+++ b/src/cmd/app/pkg/fs/pull_pkg_fs.rs
@@ -2,6 +2,7 @@ use crate::cmd::app::pkg::fs::prepare_pkg_fs_folder;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
 use crate::cmd::cli::CliCommand;
 use crate::pkg::utils::get_package_name_from_folder;
+use anstyle::Style;
 use clap::Args;
 use std::error::Error;
 use std::path::PathBuf;
@@ -33,7 +34,10 @@ impl AppCommand for PullPkgFsCommand {
         }
         .run(app)?;
 
-        eprintln!("Package {} pulled successfully!", &package_name);
+        eprintln!(
+            "{bold}{package_name}{bold:#} package pulled successfully!",
+            bold = Style::new().bold()
+        );
 
         crate::cmd::pkg::apply::ApplyCommand {
             package_folder: package_folder.to_owned(),

--- a/src/cmd/app/pkg/fs/push_pkg_fs.rs
+++ b/src/cmd/app/pkg/fs/push_pkg_fs.rs
@@ -1,6 +1,7 @@
 use crate::cmd::app::pkg::fs::prepare_pkg_fs_folder;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
 use crate::pkg::utils::get_package_name_from_folder;
+use anstyle::Style;
 use clap::Args;
 use std::error::Error;
 use std::path::PathBuf;
@@ -37,7 +38,10 @@ impl AppCommand for PushPkgFsCommand {
         }
         .run(app)?;
 
-        eprintln!("Package {} pushed successfully!", &package_name);
+        eprintln!(
+            "{bold}{package_name}{bold:#} package pushed successfully!",
+            bold = Style::new().bold()
+        );
 
         if self.compile_package_after_push {
             eprintln!("Compiling package...");

--- a/src/cmd/app/pkg/install_pkg.rs
+++ b/src/cmd/app/pkg/install_pkg.rs
@@ -1,4 +1,5 @@
 use crate::app::{CrtClient, CrtClientGenericError, InstallLogWatcher, InstallLogWatcherEvent};
+use crate::cmd::app::restart::print_app_restart_requested;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
 use clap::Args;
 use std::error::Error;
@@ -126,11 +127,7 @@ pub fn install_package_from_stream_command(
             .restart_app()
             .map_err(InstallPkgCommandError::AppRestart)?;
 
-        eprintln!("Application restart has been requested");
-
-        if !client.is_net_framework() {
-            eprintln!("Note: if restart does not work, please check if you need to use --net-framework flag");
-        }
+        print_app_restart_requested(&client);
     }
 
     return Ok(());

--- a/src/cmd/app/pkg/pull_pkg.rs
+++ b/src/cmd/app/pkg/pull_pkg.rs
@@ -1,7 +1,7 @@
 use crate::app::CrtClientGenericError;
 use crate::cmd::app::pkg::DetectTargetPackageNameError;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
-use crate::cmd::pkg::config_file::CrtCliPkgConfig;
+use crate::cmd::pkg::config_file::{combine_apply_features_from_args_and_config, CrtCliPkgConfig};
 use crate::pkg::bundling::extractor::*;
 use clap::Args;
 use std::error::Error;
@@ -47,10 +47,11 @@ impl AppCommand for PullPkgCommand {
 
         let pkg_config = CrtCliPkgConfig::from_package_folder(destination_folder)?;
 
-        let apply_features = pkg_config
-            .map(|c| c.apply().combine(self.apply_features.as_ref()))
-            .or_else(|| self.apply_features.clone())
-            .unwrap_or_default();
+        let apply_features = combine_apply_features_from_args_and_config(
+            self.apply_features.as_ref(),
+            pkg_config.as_ref(),
+        )
+        .unwrap_or_default();
 
         let package_name = detect_target_package_name!(self.package_name, destination_folder);
 

--- a/src/cmd/app/pkgs.rs
+++ b/src/cmd/app/pkgs.rs
@@ -1,4 +1,5 @@
 use crate::cmd::app::{AppCommand, AppCommandArgs};
+use anstyle::Style;
 use clap::Args;
 use std::error::Error;
 
@@ -17,9 +18,7 @@ impl AppCommand for PkgsCommand {
             .get_packages()?;
 
         match self.json {
-            true => {
-                println!("{}", serde_json::json!(packages))
-            }
+            true => println!("{}", serde_json::json!(packages)),
             false => {
                 for package in &packages {
                     println!("{package}");
@@ -27,7 +26,11 @@ impl AppCommand for PkgsCommand {
             }
         }
 
-        eprintln!("Total: {} packages", packages.len());
+        eprintln!(
+            "{style}Total: {} packages{style:#}",
+            packages.len(),
+            style = Style::new().underline()
+        );
 
         Ok(())
     }

--- a/src/cmd/app/restart.rs
+++ b/src/cmd/app/restart.rs
@@ -1,4 +1,6 @@
+use crate::app::CrtClient;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
+use anstyle::Style;
 use clap::Args;
 use std::error::Error;
 
@@ -11,12 +13,19 @@ impl AppCommand for RestartCommand {
 
         client.app_installer_service().restart_app()?;
 
-        eprintln!("Application restart has been requested");
-
-        if !client.is_net_framework() {
-            eprintln!("Note: if restart does not work, please check if you need to use --net-framework flag");
-        }
+        print_app_restart_requested(&client);
 
         Ok(())
+    }
+}
+
+pub fn print_app_restart_requested(client: &CrtClient) {
+    eprintln!("Application restart has been requested");
+
+    if !client.is_net_framework() {
+        eprintln!(
+            "{style}Note: if restart does not work, please check if you need to use --net-framework flag{style:#}",
+            style=Style::new().dimmed()
+        );
     }
 }

--- a/src/cmd/app/sql.rs
+++ b/src/cmd/app/sql.rs
@@ -1,5 +1,6 @@
 use crate::app::sql::SqlRunner;
 use crate::cmd::app::{AppCommand, AppCommandArgs};
+use anstyle::Style;
 use clap::{Args, ValueEnum};
 use serde::Serialize;
 use std::error::Error;
@@ -65,21 +66,29 @@ impl AppCommand for SqlCommand {
         return Ok(());
 
         fn read_data_from_stdin() -> Result<String, std::io::Error> {
+            let dimmed = Style::new().dimmed();
+            let italic = Style::new().italic();
+
             eprintln!("Please enter SQL query below: ");
-            eprintln!("-=-=- -=-=- -=-=- -=-=- -=-=-");
-            eprintln!();
+            eprintln!("{dimmed}-=-=- -=-=- -=-=- -=-=- -=-=-{dimmed:#}");
+            eprintln!("{italic}");
 
             let mut data = String::new();
 
             loop {
-                if stdin().lock().read_line(&mut data)? == 1 {
+                if stdin()
+                    .lock()
+                    .read_line(&mut data)
+                    .inspect_err(|_| eprint!("{italic:#}"))?
+                    == 1
+                {
                     break;
                 }
             }
 
             data.truncate(data.len() - 2);
 
-            eprintln!("-=-=- -=-=- -=-=- -=-=- -=-=-");
+            eprintln!("{dimmed}-=-=- -=-=- -=-=- -=-=- -=-=-{dimmed:#}");
             eprintln!();
 
             Ok(data)

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -116,7 +116,7 @@ fn print_fish_completions(cmd: &mut Command) {
         &mut completions,
     );
 
-    let completions_str = String::from_utf8_lossy(&mut completions);
+    let completions_str = String::from_utf8_lossy(&completions);
     let completions_str = postprocess_fish_completions(&completions_str);
 
     std::io::stdout()
@@ -126,7 +126,7 @@ fn print_fish_completions(cmd: &mut Command) {
 
     return;
 
-    fn postprocess_fish_completions<'a>(completions_str: &'a Cow<str>) -> Cow<'a, str> {
+    fn postprocess_fish_completions(completions_str: &str) -> Cow<'_, str> {
         return fix_app_subcommand_completions(completions_str);
 
         /// Patches suggestions for `crtcli app ...` subcommands for fish shell.
@@ -137,7 +137,7 @@ fn print_fish_completions(cmd: &mut Command) {
         ///
         /// This cause after use suggestions for `crtcli app ` you receive also file suggestions.
         /// After this patch, you will receive only suggestions for `crtcli app <subcommand>` for this.
-        fn fix_app_subcommand_completions<'a>(completions_str: &'a Cow<str>) -> Cow<'a, str> {
+        fn fix_app_subcommand_completions(completions_str: &str) -> Cow<'_, str> {
             let app_subcommand_completions_regex = Regex::new(
                 r#"(complete -c crtcli -n "__fish_crtcli_using_subcommand app; and not __fish_seen_subcommand_from .+?") -a ""#
             )

--- a/src/cmd/pkg/config_file.rs
+++ b/src/cmd/pkg/config_file.rs
@@ -47,3 +47,12 @@ impl CrtCliPkgConfig {
         }
     }
 }
+
+pub fn combine_apply_features_from_args_and_config(
+    args_features: Option<&PkgApplyFeatures>,
+    pkg_config: Option<&CrtCliPkgConfig>,
+) -> Option<PkgApplyFeatures> {
+    args_features
+        .map(|c| c.combine(pkg_config.map(|c| c.apply())))
+        .or_else(|| pkg_config.map(|c| c.apply().clone()))
+}

--- a/src/cmd/pkg/unpack.rs
+++ b/src/cmd/pkg/unpack.rs
@@ -1,6 +1,6 @@
 use crate::cmd::cli::CliCommand;
 use crate::cmd::pkg::apply::PkgApplyFeatures;
-use crate::cmd::pkg::config_file::CrtCliPkgConfig;
+use crate::cmd::pkg::config_file::{combine_apply_features_from_args_and_config, CrtCliPkgConfig};
 use crate::pkg::bundling::extractor::*;
 use clap::Args;
 use std::error::Error;
@@ -81,10 +81,11 @@ impl CliCommand for UnpackCommand {
 
         let pkg_config = CrtCliPkgConfig::from_package_folder(&destination_folder)?;
 
-        let apply_features = pkg_config
-            .map(|c| c.apply().combine(self.apply_features.as_ref()))
-            .or(self.apply_features)
-            .unwrap_or_default();
+        let apply_features = combine_apply_features_from_args_and_config(
+            self.apply_features.as_ref(),
+            pkg_config.as_ref(),
+        )
+        .unwrap_or_default();
 
         let extractor_config = PackageToFolderExtractorConfig::default()
             .with_files_already_exists_in_folder_strategy(match self.merge {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate anstream;
 
+use anstyle::{AnsiColor, Color, Style};
 use clap::Parser;
-use owo_colors::OwoColorize;
 use std::process::ExitCode;
 
 mod app;
@@ -19,11 +19,19 @@ fn main() -> ExitCode {
     match cli.run() {
         Ok(_) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("{} {:#}", "Error:".red(), err.red());
+            eprintln!(
+                "{style}Error: {err:#}{style:#}",
+                style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)))
+            );
 
             if is_debug {
                 eprintln!();
-                eprintln!("Error (Debug-view): {:?}", err);
+                eprintln!(
+                    "{style}Error (Debug-view): {err:?}{style:#}",
+                    style = Style::new()
+                        .fg_color(Some(Color::Ansi(AnsiColor::BrightRed)))
+                        .dimmed()
+                );
             }
 
             ExitCode::FAILURE

--- a/src/pkg/bundling/extractor.rs
+++ b/src/pkg/bundling/extractor.rs
@@ -4,7 +4,7 @@ use crate::pkg::bundling::utils::{
 use crate::pkg::bundling::PkgGZipDecoder;
 use crate::pkg::converters::*;
 use crate::pkg::utils::contains_hidden_path;
-use owo_colors::OwoColorize;
+use anstyle::{AnsiColor, Color, Style};
 use std::collections::HashSet;
 use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
@@ -149,9 +149,9 @@ impl SmartMergeContext {
 
                 if result && config.print_merge_log {
                     eprintln!(
-                        "\t{}\t{}",
-                        "deleted:".red(),
-                        path_without_dest.display().red()
+                        "{style}\tdeleted:\t{}{style:#}",
+                        path_without_dest.display(),
+                        style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)))
                     );
                 }
 
@@ -259,7 +259,10 @@ pub fn extract_gzip_package_to_folder(
     ) -> Result<bool, ExtractGzipPackageError> {
         if !destination_path.exists() {
             if config.print_merge_log {
-                eprintln!("\t{}\t{}", "created:".green(), relative_path.green());
+                eprintln!(
+                    "{style}\tcreated:\t{relative_path}{style:#}",
+                    style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)))
+                );
             }
 
             return Ok(true);
@@ -279,7 +282,7 @@ pub fn extract_gzip_package_to_folder(
                     .map_or(false, |exists_content| exists_content != *content);
 
                 if result && config.print_merge_log {
-                    eprintln!("\t{}\t{}", "modified:", relative_path);
+                    eprintln!("\tmodified:\t{relative_path}");
                 }
 
                 Ok(result)


### PR DESCRIPTION
In this PR:
- migrated from owo-colors to anstyle crate
- some command receives more colorful output
- cmd/app/request: display body as pretty json if possible, some headers output
- fix combined apply features config: now features from cmd args has more priorty compared to defined in file
- cargo: disable debug symbols for dev profile to speedup build