### PR TITLE
feat: improve data.json & data.*.json values sorting

### DIFF
--- a/src/pkg/json-wrappers/pkg_data_data.rs
+++ b/src/pkg/json-wrappers/pkg_data_data.rs
@@ -1,6 +1,7 @@
 use crate::pkg::json_wrappers::PkgJsonWrapper;
 use regex::Regex;
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::ops::Deref;
 use std::sync::LazyLock;
 use thiserror::Error;
@@ -20,6 +21,9 @@ pub static PKG_DATA_LCZ_DATA_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     ))
     .expect("failed to compile regex for package data lcz data file path regex")
 });
+
+const PKG_DATA_DATA_SCHEMA_COLUMN_UID_VALUE_ID_COLUMN: &str =
+    "ae0e45ca-c495-4fe7-a39d-3ab7278e1617";
 
 pub struct PkgDataDataJsonWrapper {
     inner_wrapper: PkgJsonWrapper,
@@ -61,12 +65,13 @@ impl PkgDataDataJsonWrapper {
     }
 
     pub fn apply_sorting(&mut self) -> Result<&mut Self, PkgDataDataSortingError> {
-        for data in self
+        let data = self
             .package_data_mut()
             .as_array_mut()
-            .ok_or(PkgDataDataSortingError::FailedToGetPackageDataArray)?
-        {
-            let row = (*data)["Row"]
+            .ok_or(PkgDataDataSortingError::FailedToGetPackageDataArray)?;
+
+        for item in data.iter_mut() {
+            let row = (*item)["Row"]
                 .as_array_mut()
                 .ok_or(PkgDataDataSortingError::FailedToGetPackageDataRowArray)?;
 
@@ -76,6 +81,29 @@ impl PkgDataDataJsonWrapper {
                     .cmp(&k2["SchemaColumnUId"].as_str())
             });
         }
+
+        data.sort_by(|k1, k2| {
+            // Safe to unwrap because we already checked this field previous iteration
+            let k1_row = (*k1)["Row"].as_array().unwrap();
+            let k2_row = (*k2)["Row"].as_array().unwrap();
+
+            let id_1 = k1_row.iter().find(|&x| {
+                x["SchemaColumnUId"].as_str()
+                    == Some(PKG_DATA_DATA_SCHEMA_COLUMN_UID_VALUE_ID_COLUMN)
+            });
+
+            let id_2 = k2_row.iter().find(|&x| {
+                x["SchemaColumnUId"].as_str()
+                    == Some(PKG_DATA_DATA_SCHEMA_COLUMN_UID_VALUE_ID_COLUMN)
+            });
+
+            match (id_1, id_2) {
+                (Some(id_1), Some(id_2)) => id_1["Value"].as_str().cmp(&id_2["Value"].as_str()),
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (None, None) => Ordering::Equal,
+            }
+        });
 
         Ok(self)
     }


### PR DESCRIPTION
While the previous sorting algorithm only sorted columns per row, the new algorithm also sorts rows when `SchemaColumnUId = ae0e45ca-c495-4fe7-a39d-3ab7278e1617` is present. (Id column in object that extends Base)