### PR TITLE
bugfix: app pkgs check result even if status = 2xx

### DIFF
--- a/src/app/app_installer.rs
+++ b/src/app/app_installer.rs
@@ -25,9 +25,7 @@ impl<'c> AppInstallerService<'c> {
             .send_with_session(self.0)?
             .error_for_status()?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 
     pub fn clear_redis_db(&self) -> Result<(), CrtClientError> {
@@ -41,9 +39,7 @@ impl<'c> AppInstallerService<'c> {
             .send_with_session(self.0)?
             .error_for_status()?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 
     #[allow(dead_code)]
@@ -64,13 +60,10 @@ impl<'c> AppInstallerService<'c> {
                 "Name": name,
                 "ZipPackageName": package_filename
             }))
-            .header(reqwest::header::CONTENT_LENGTH, "0")
             .send_with_session(self.0)?
             .error_for_status()?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 
     pub fn load_packages_to_db<StrArr, Str>(

--- a/src/app/client.rs
+++ b/src/app/client.rs
@@ -341,8 +341,6 @@ pub enum CrtClientError {
 
     #[error("sql runner error: {0}")]
     SqlRunner(#[from] Box<sql::SqlRunnerError>),
-    // #[error("failed to access the cache: {0}")]
-    // AccessCache(#[from] AccessCacheError)
 }
 
 impl From<auth::LoginError> for CrtClientError {

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -22,13 +22,11 @@ impl<'c> PackageService<'c> {
             )
             .json(&json!(package_uid))
             .send_with_session(self.0)?
-            .error_for_status()
-            .map_err(CrtClientError::from)?;
+            .error_for_status()?;
 
-        let response: GetPackagePropertiesResponse =
-            response.json().map_err(CrtClientError::from)?;
-
-        response.into_result()
+        response
+            .json::<GetPackagePropertiesResponse>()?
+            .into_result()
     }
 }
 

--- a/src/app/package_installer.rs
+++ b/src/app/package_installer.rs
@@ -78,9 +78,7 @@ impl<'c> PackageInstallerService<'c> {
             .send_with_session(self.0)?
             .error_for_status()?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 
     pub fn install_package(&self, package_filename: &str) -> Result<(), CrtClientError> {
@@ -93,9 +91,7 @@ impl<'c> PackageInstallerService<'c> {
             .json(&json!(package_filename))
             .send_with_session(self.0)?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 
     #[allow(dead_code)]
@@ -117,8 +113,6 @@ impl<'c> PackageInstallerService<'c> {
             .send_with_session(self.0)?
             .error_for_status()?;
 
-        response.json::<StandardServiceResponse>()?.into_result()?;
-
-        Ok(())
+        Ok(response.json::<StandardServiceResponse>()?.into_result()?)
     }
 }


### PR DESCRIPTION
This bug fixes `app pkgs` behavior when current user have insufficient permissions to see packages list. 

In that case command output contains message about failure to parse response, not about insufficient permissions.