### PR TITLE
feat(install-script): CRTCLI_INSTALL_VERSION_TAG env variable support

### DIFF
--- a/install-unix.sh
+++ b/install-unix.sh
@@ -34,10 +34,23 @@ detect_os() {
 }
 
 fetch_target_url() {
-  releases=$(fetch https://api.github.com/repos/heabijay/crtcli/releases/latest)
+  if [ -n "$CRTCLI_INSTALL_VERSION_TAG" ]; then
+    tag="$CRTCLI_INSTALL_VERSION_TAG"
+    releases_url="https://api.github.com/repos/heabijay/crtcli/releases/tags/$tag"
+  else
+    releases_url="https://api.github.com/repos/heabijay/crtcli/releases/latest"
+  fi
+
+  releases=$(fetch "$releases_url")
+
   url=$(echo "$releases" | grep -wo -m1 "https://.*$target.tar.gz" || true)
+
   if ! test "$url"; then
-    echo "Error: Cannot find release info for $target."
+    if [ -n "$CRTCLI_INSTALL_VERSION_TAG" ]; then
+      echo "Error: Cannot find release info for $target with tag $tag."
+    else
+      echo "Error: Cannot find release info for $target."
+    fi
     exit 1
   fi
 }

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -4,7 +4,14 @@
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $ProgressPreference = 'SilentlyContinue'
-$release = Invoke-RestMethod -Method Get -Uri "https://api.github.com/repos/heabijay/crtcli/releases/latest"
+
+if ($env:CRTCLI_INSTALL_VERSION_TAG) {
+    $releaseUrl = "https://api.github.com/repos/heabijay/crtcli/releases/tags/$($env:CRTCLI_INSTALL_VERSION_TAG)"
+} else {
+    $releaseUrl = "https://api.github.com/repos/heabijay/crtcli/releases/latest"
+}
+
+$release = Invoke-RestMethod -Method Get -Uri $releaseUrl
 $asset = $release.assets | Where-Object name -like *x86_64-pc-windows*.zip
 $destdir = "$env:LOCALAPPDATA\crtcli"
 $zipfile = "$env:TEMP\$( $asset.name )"


### PR DESCRIPTION
Now, you can export the CRTCLI_INSTALL_VERSION_TAG variable before executing the install script to install a specific version of crtcli.

Example:
```bash
export CRTCLI_INSTALL_VERSION_TAG=v0.1.1; curl -sfL https://raw.githubusercontent.com/heabijay
/crtcli/main/install-unix.sh | sh
```