### PR TITLE
feat(app pkg install): stdin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
- - Added `app tunnel` command which allows to establish TCP tunnels via the Creatio instance ([#20](https://github.com/heabijay/crtcli/pull/21))
+ - Added `app tunnel` command which allows to establish TCP tunnels via the Creatio instance ([#21](https://github.com/heabijay/crtcli/pull/21))
+
+ - Added stdin option to `app pkg install` using '@-' or '-' as filename ([#22](https://github.com/heabijay/crtcli/pull/22))
 
 
 ## [0.1.3](https://github.com/heabijay/crtcli/releases/tag/v0.1.3) (2025-03-25)

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Installs a package archive (.zip or .gz) into the Creatio instance.
 
 **Arguments:**
 
-- `<FILEPATH>` (required) — Path to the package archive file.
+- `<FILEPATH>` (required) — Path to the package archive file. (Use '@-' or '-' value to read data from standard input)
 
 **Options:**
 

--- a/src/crtcli/Cargo.toml
+++ b/src/crtcli/Cargo.toml
@@ -13,29 +13,29 @@ anstyle = "1.0.10"
 async-trait = "0.1.88"
 bincode = "2.0.1"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-clap_complete = "4.5.47"
+clap_complete = "4.5.50"
 dotenvy = "0.15.7"
 flate2 = "1.1.1"
 futures = "0.3.31"
 hyper-util = "0.1.11"
 indexmap = { version =  "2.9.0", features = ["serde"] }
 indicatif = "0.17.11"
-quick-xml = "0.37.4"
-rustls = { version = "0.23.26", features = ["ring"] }
+quick-xml = "0.37.5"
+rustls = { version = "0.23.27", features = ["ring"] }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 thiserror = "2.0.12"
-tokio = { version = "1.44.2", features = ["macros"] }
+tokio = { version = "1.45.0", features = ["macros"] }
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7.14", features = ["io", "io-util"] }
-toml = "0.8.20"
+tokio-util = { version = "0.7.15", features = ["io", "io-util"] }
+toml = "0.8.22"
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
-zip = "2.6.1"
+zip = "3.0.0"
 
 [dependencies.clap]
-version = "4.5.36"
+version = "4.5.38"
 features = ["derive", "env", "suggestions", "usage"]
 
 [dependencies.time]


### PR DESCRIPTION
In this PR, you can use stdin with the `app pkg install` command instead of providing an actual file.

Example (download & install crtcli.tunneling v0.1.0 package):
```bash
curl -sfL https://github.com/user-attachments/files/19711059/crtcli.tunneling_v0.1.0.zip | crtcli app pkg install @- -r
```