### PR TITLE
feat: OAuth 2.0 authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
  - Added `app tunnel` command which allows to establish TCP tunnels via the Creatio instance ([#21](https://github.com/heabijay/crtcli/pull/21))
 
- - Added stdin option to `app pkg install` using '@-' or '-' as filename ([#22](https://github.com/heabijay/crtcli/pull/22))
+ - Stdin option to `app pkg install` using '@-' or '-' as filename ([#22](https://github.com/heabijay/crtcli/pull/22))
+
+ - Implemented OAuth 2 authentication support to `crtcli app` commands ([#23](https://github.com/heabijay/crtcli/pull/23))
+
+ - Flag `--force-new-session` for `crtcli app` commands just in case you need to invalidate session cache before executing ([#23](https://github.com/heabijay/crtcli/pull/23))
 
 
 ## [0.1.3](https://github.com/heabijay/crtcli/releases/tag/v0.1.3) (2025-03-25)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,35 @@ Please check [dotenv (.env) files](#dotenv-env-files) and [workspace.crtcli.toml
 
   By default, crtcli primary uses .NET Core / .NET (Kestrel) API routes to operate with remote. However, some features like "app restart" works by different API routes in both platforms.
 
+- `--force-new-session` — Forcefully revoke the cached session and use a new one. Use if you need to log out and log in.
+
+For OAuth 2.0 authentication (instead of username and password):
+
+- `--oauth-url` (env: `CRTCLI_APP_OAUTH_URL`) — (OAuth 2.0) Creatio OAuth URL (Identity Server).
+
+- `--oauth-client-id` (env: `CRTCLI_APP_OAUTH_CLIENT_ID`) — (OAuth 2.0) Creatio OAuth Client ID.
+
+- `--oauth-client-secret` (env: `CRTCLI_APP_OAUTH_CLIENT_SECRET`) — (OAuth 2.0) Creatio OAuth Client Secret.
+
+**Examples:**
+
+- `crtcli app https://localhost:5000 Supervisor Supervisor1 -i <COMMAND>` — Executes the specified \<COMMAND\> on an insecure Creatio instance at `https://localhost:5000` using the `Supervisor` username and `Supervisor1` password.
+
+-
+  ```sh
+  crtcli app https://production.creatio.com \
+    --oauth-url https://production-is.creatio.com \
+    --oauth-client-id A3F4C1B0E2D5F8A7B6C9D0E1F2A3B4C5 \
+    --oauth-client-secret 8F3C7E1B0D6A5F9E2C4B7D0A1E3F6C9B5A8D7E6F1C0B3A2D5E7F9C1B0D6A5F9E \
+    --net-framework \
+    <COMMAND>
+  ```
+  — Executes the specified \<COMMAND\> on the `https://production.creatio.com` Creatio instance, using .NET Framework (IIS) compatibility and OAuth 2.0 authentication via the `https://production-is.creatio.com` Identity Server, with Client ID `_A3F4C..._` and Client Secret `_8F3C7..._`.
+
+- `crtcli app <COMMAND>` — Executes the specified \<COMMAND\> on the Creatio instance configured via [environment variables / .env file](#dotenv-env-files).
+
+- `crtcli app prod <COMMAND>` — Executes the specified \<COMMAND\> on the Creatio instance configured with the `prod` alias in [workspace.crtcli.toml](#workspacecrtclitoml).
+
 
 ### app compile
 
@@ -121,8 +150,6 @@ Compiles the Creatio application (equivalent to the "Build" or "Rebuild" action 
 **Examples:**
 
 - `crtcli app https://localhost:5000 Supervisor Supervisor -i compile` — Compiles the Creatio instance at insecure https://localhost:5000.
-
-- `crtcli app dev compile -r` — Compiles the Creatio instance specified by the 'dev' alias from workspace.crtcli.toml and restarting afterward.
 
 - `crtcli app compile -fr` — Compiles the Creatio instance specified by the $CRTCLI_APP_URL environment variable, using a forced rebuild and restarting afterward.
 
@@ -1047,6 +1074,12 @@ Locations: '.env', '.crtcli.env' in current directory or any parent folders.
 
 - `CRTCLI_APP_NETFRAMEWORK` — Set to 'true' if your Creatio instance is running on .NET Framework (IIS) by default.
 
+For OAuth 2.0 authentication (instead of username and password):
+
+- `CRTCLI_APP_OAUTH_URL` — The OAuth URL (Identity Server).
+- `CRTCLI_APP_OAUTH_CLIENT_ID` — The OAuth Client ID.
+- `CRTCLI_APP_OAUTH_CLIENT_SECRET` — The OAuth Client Secret.
+
 **Examples:**
 
 For example, current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/UsrPackage' which is package folder inside in Creatio. 
@@ -1127,6 +1160,12 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
 - `apps.<alias>.insecure` — (Optional) Set to `true` to disable SSL certificate validation.
 - `apps.<alias>.net_framework` — (Optional) Set to `true` if your Creatio instance is running on .NET Framework (IIS).
 
+For OAuth 2.0 authentication (instead of username and password):
+
+- `apps.<alias>.oauth_url` — The OAuth URL (Identity Server).
+- `apps.<alias>.oauth_client_id` — The OAuth Client ID.
+- `apps.<alias>.oauth_client_secret` — The OAuth Client Secret.
+
 **Examples:**
 
 1. For example, if the current folder is `/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/UsrPackage`, which represents a package folder in Creatio, you could have the following files with the specified content:
@@ -1153,8 +1192,9 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
         
         [apps.prod]
         url = "https://production.creatio.com"
-        username = "Supervisor"
-        password = "StrongPassword123!!!"
+        oauth_url = "https://production-is.creatio.com"
+        oauth_client_id = "my-client-id"
+        oauth_client_secret = "my-client-secret"
         ```
    - _/Creatio_8.1.5.2176/.env_:
 
@@ -1173,7 +1213,7 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
 
    - `crtcli app dev restart` — Restarts the development Creatio instance (insecure .NET Framework based `https://development.creatio.com` with `Supervisor:Supervisor@1` credentials).
    
-   - `crtcli app prod pkg download CrtBase` — Downloads the `CrtBase` package from the production Creatio instance (`https://production.creatio.com` with `Supervisor:StrongPassword123!!!` credentials).
+   - `crtcli app prod pkg download CrtBase` — Downloads the `CrtBase` package from the production Creatio instance using OAuth 2.0 authentication (with the `https://production-is.creatio.com` Identity Server, Client ID `my-client-id`, and Client Secret `my-client-secret`).
 
 ---
 

--- a/src/crtcli/src/app/auth.rs
+++ b/src/crtcli/src/app/auth.rs
@@ -1,7 +1,6 @@
-use crate::app::CrtClientError;
 use crate::app::client::CrtClient;
-use crate::app::session::CrtSession;
 use crate::app::utils::{CookieParsingError, collect_set_cookies, find_cookie_by_name};
+use crate::app::{CrtClientError, CrtSessionCookie};
 use reqwest::Method;
 use serde::Deserialize;
 use serde_json::json;
@@ -14,7 +13,11 @@ impl<'c> AuthService<'c> {
         Self(client)
     }
 
-    pub async fn login(&self, username: &str, password: &str) -> Result<CrtSession, LoginError> {
+    pub async fn login(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<CrtSessionCookie, LoginError> {
         let response = self
             .0
             .request(Method::POST, "ServiceModel/AuthService.svc/Login")
@@ -43,7 +46,7 @@ impl<'c> AuthService<'c> {
 
         let csrftoken = find_cookie_by_name(&set_cookies, "CsrfToken");
 
-        Ok(CrtSession::new(aspxauth, bpmcrsf, csrftoken, None))
+        Ok(CrtSessionCookie::new(aspxauth, bpmcrsf, csrftoken, None))
     }
 }
 

--- a/src/crtcli/src/app/credentials.rs
+++ b/src/crtcli/src/app/credentials.rs
@@ -1,30 +1,50 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct CrtCredentials {
-    url: String,
-    username: String,
-    password: String,
+pub enum CrtCredentials {
+    Basic {
+        url: String,
+        username: String,
+        password: String,
+    },
+    OAuth {
+        url: String,
+        oauth_url: String,
+        oauth_client_id: String,
+        oauth_client_secret: String,
+    },
 }
 
 impl CrtCredentials {
     pub fn new(url: &str, username: &str, password: &str) -> CrtCredentials {
-        CrtCredentials {
+        CrtCredentials::Basic {
             url: url.trim_end_matches("/").to_owned(),
             username: username.to_owned(),
             password: password.to_owned(),
         }
     }
 
+    pub fn new_oauth(
+        url: &str,
+        oauth_url: &str,
+        oauth_client_id: &str,
+        oauth_client_secret: &str,
+    ) -> CrtCredentials {
+        CrtCredentials::OAuth {
+            url: url.trim_end_matches("/").to_owned(),
+            oauth_url: oauth_url
+                .trim_end_matches("/")
+                .trim_end_matches("/connect/token")
+                .to_owned(),
+            oauth_client_id: oauth_client_id.to_owned(),
+            oauth_client_secret: oauth_client_secret.to_owned(),
+        }
+    }
+
     pub fn url(&self) -> &str {
-        &self.url
-    }
-
-    pub fn username(&self) -> &str {
-        &self.username
-    }
-
-    pub fn password(&self) -> &str {
-        &self.password
+        match &self {
+            CrtCredentials::Basic { url, .. } => url,
+            CrtCredentials::OAuth { url, .. } => url,
+        }
     }
 }

--- a/src/crtcli/src/app/mod.rs
+++ b/src/crtcli/src/app/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod oauth;
 
 mod client;
 pub use client::*;

--- a/src/crtcli/src/app/oauth.rs
+++ b/src/crtcli/src/app/oauth.rs
@@ -1,0 +1,67 @@
+use crate::app::CrtSessionOAuth;
+use reqwest::Client;
+use serde::Deserialize;
+use thiserror::Error;
+
+pub struct OAuthService<'c> {
+    reqwest_client: &'c Client,
+    oauth_base_url: &'c str,
+}
+
+impl<'c> OAuthService<'c> {
+    pub fn new(reqwest_client: &'c Client, oauth_base_url: &'c str) -> Self {
+        OAuthService {
+            reqwest_client,
+            oauth_base_url,
+        }
+    }
+
+    pub async fn connect_token(
+        &self,
+        client_id: String,
+        client_secret: String,
+    ) -> Result<CrtSessionOAuth, OAuthLoginError> {
+        let response = self
+            .reqwest_client
+            .post(format!("{}/connect/token", self.oauth_base_url))
+            .form(&[
+                ("client_id", client_id),
+                ("client_secret", client_secret),
+                ("grant_type", "client_credentials".to_owned()),
+            ])
+            .send()
+            .await?;
+
+        if response.status() == reqwest::StatusCode::BAD_REQUEST {
+            let error = response
+                .json::<OAuthErrorContract>()
+                .await
+                .map_err(OAuthLoginError::ResponseRead)?;
+
+            return Err(OAuthLoginError::Remote(error.error));
+        }
+
+        response
+            .error_for_status()?
+            .json::<CrtSessionOAuth>()
+            .await
+            .map_err(OAuthLoginError::ResponseRead)
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum OAuthLoginError {
+    #[error("request error: {0}")]
+    Request(#[from] reqwest::Error),
+
+    #[error("response read error: {0}")]
+    ResponseRead(#[source] reqwest::Error),
+
+    #[error("{0}")]
+    Remote(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthErrorContract {
+    error: String,
+}

--- a/src/crtcli/src/app/session.rs
+++ b/src/crtcli/src/app/session.rs
@@ -1,28 +1,44 @@
 use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
-pub struct CrtSession {
+pub enum CrtSession {
+    Cookie(CrtSessionCookie),
+    OAuthSession(CrtSessionOAuth),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct CrtSessionCookie {
     aspxauth: String,
     bpmcsrf: String,
     csrftoken: Option<String>,
     bpmsessionid: Option<String>,
 }
 
-impl CrtSession {
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, Serialize, Deserialize)]
+pub struct CrtSessionOAuth {
+    access_token: String,
+    expires_in: i64,
+    token_type: String,
+}
+
+impl CrtSessionCookie {
     pub fn new(
         aspxauth: String,
         bpmcsrf: String,
         csrftoken: Option<String>,
         bpmsessionid: Option<String>,
-    ) -> CrtSession {
-        Self {
+    ) -> CrtSessionCookie {
+        CrtSessionCookie {
             aspxauth,
             bpmcsrf,
             csrftoken,
             bpmsessionid,
         }
     }
+}
 
+impl CrtSessionCookie {
     pub fn to_cookie_value(&self) -> String {
         let mut cookie_value =
             format!(".ASPXAUTH={};BPMCSRF={};", self.aspxauth, self.bpmcsrf).to_owned();
@@ -48,5 +64,19 @@ impl CrtSession {
 
     pub fn set_bpmsessionid(&mut self, bpmsessionid: Option<String>) {
         self.bpmsessionid = bpmsessionid;
+    }
+}
+
+impl CrtSessionOAuth {
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    pub fn token_type(&self) -> &str {
+        &self.token_type
+    }
+
+    pub fn expires_in(&self) -> i64 {
+        self.expires_in
     }
 }

--- a/src/crtcli/src/cmd/app/mod.rs
+++ b/src/crtcli/src/cmd/app/mod.rs
@@ -52,28 +52,26 @@ pub struct AppCommandArgs {
     url: String,
 
     /// Creatio Username [default: Supervisor]
-    #[arg(short, long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_USERNAME")]
+    #[arg(value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_USERNAME")]
     username: Option<String>,
 
     /// Creatio Password [default: Supervisor]
     #[arg(
-        short,
-        long,
         value_hint = clap::ValueHint::Other,
         env = "CRTCLI_APP_PASSWORD",
         hide_env_values = true
     )]
     password: Option<String>,
 
-    /// (OAuth) Creatio OAuth URL
+    /// (OAuth 2.0) Creatio OAuth URL (Identity Server)
     #[arg(long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_OAUTH_URL")]
     oauth_url: Option<String>,
 
-    /// (OAuth) Creatio OAuth Client ID
+    /// (OAuth 2.0) Creatio OAuth Client ID
     #[arg(long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_OAUTH_CLIENT_ID")]
     oauth_client_id: Option<String>,
 
-    /// (OAuth) Creatio OAuth Client Secret
+    /// (OAuth 2.0) Creatio OAuth Client Secret
     #[arg(
         long,
         value_hint = clap::ValueHint::Other,
@@ -93,7 +91,7 @@ pub struct AppCommandArgs {
     #[arg(long = "net-framework", env = "CRTCLI_APP_NETFRAMEWORK")]
     net_framework: bool,
 
-    /// Revoke the cached session to force a new one
+    /// Forcefully revoke the cached session and use a new one
     #[arg(long = "force-new-session")]
     force_new_session: bool,
 }

--- a/src/crtcli/src/cmd/app/mod.rs
+++ b/src/crtcli/src/cmd/app/mod.rs
@@ -52,12 +52,35 @@ pub struct AppCommandArgs {
     url: String,
 
     /// Creatio Username [default: Supervisor]
-    #[arg(value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_USERNAME")]
+    #[arg(short, long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_USERNAME")]
     username: Option<String>,
 
     /// Creatio Password [default: Supervisor]
-    #[arg(value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_PASSWORD")]
+    #[arg(
+        short,
+        long,
+        value_hint = clap::ValueHint::Other,
+        env = "CRTCLI_APP_PASSWORD",
+        hide_env_values = true
+    )]
     password: Option<String>,
+
+    /// (OAuth) Creatio OAuth URL
+    #[arg(long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_OAUTH_URL")]
+    oauth_url: Option<String>,
+
+    /// (OAuth) Creatio OAuth Client ID
+    #[arg(long, value_hint = clap::ValueHint::Other, env = "CRTCLI_APP_OAUTH_CLIENT_ID")]
+    oauth_client_id: Option<String>,
+
+    /// (OAuth) Creatio OAuth Client Secret
+    #[arg(
+        long,
+        value_hint = clap::ValueHint::Other,
+        env = "CRTCLI_APP_OAUTH_CLIENT_SECRET", 
+        hide_env_values = true
+    )]
+    oauth_client_secret: Option<String>,
 
     /// Ignore SSL certificate errors
     #[arg(long, short, env = "CRTCLI_APP_INSECURE")]
@@ -69,6 +92,10 @@ pub struct AppCommandArgs {
     /// However, some features like "app restart" works by different API routes in both platforms.
     #[arg(long = "net-framework", env = "CRTCLI_APP_NETFRAMEWORK")]
     net_framework: bool,
+
+    /// Revoke the cached session to force a new one
+    #[arg(long = "force-new-session")]
+    force_new_session: bool,
 }
 
 #[async_trait]
@@ -130,7 +157,8 @@ impl AppCommands {
             .expect("failed to install rustls crypto provider");
 
         let args = Self::load_and_apply_workspace_config(args)?;
-        let client = Arc::new(Self::build_client(&args)?);
+        let credentials = args.get_credentials()?;
+        let client = Arc::new(Self::build_client(credentials, &args)?);
 
         match self {
             AppCommands::Compile(command) => command.run(client).await,
@@ -146,20 +174,10 @@ impl AppCommands {
         }
     }
 
-    fn build_client(args: &AppCommandArgs) -> Result<CrtClient, CrtClientError> {
-        let username = if let Some(username) = &args.username {
-            username
-        } else {
-            DEFAULT_APP_USERNAME
-        };
-
-        let password = if let Some(password) = &args.password {
-            password
-        } else {
-            DEFAULT_APP_PASSWORD
-        };
-
-        let credentials = CrtCredentials::new(&args.url, username, password);
+    fn build_client(
+        credentials: CrtCredentials,
+        args: &AppCommandArgs,
+    ) -> Result<CrtClient, CrtClientError> {
         let session = check_default_credentials_in_cache(&credentials, args);
 
         return CrtClient::builder(credentials)
@@ -172,14 +190,19 @@ impl AppCommands {
             credentials: &CrtCredentials,
             args: &AppCommandArgs,
         ) -> Option<CrtSession> {
-            let session =
-                crate::app::session_cache::create_default_session_cache().get_entry(credentials);
+            let cache = crate::app::session_cache::create_default_session_cache();
+
+            if args.force_new_session {
+                cache.remove_entry(credentials);
+            }
+
+            let session = cache.get_entry(credentials);
 
             if let Some(session) = session {
                 return Some(session);
             }
 
-            if args.username.is_none() {
+            if matches!(credentials, CrtCredentials::Basic { .. }) && args.username.is_none() {
                 eprintln!(
                     "{style}warning: Creatio username is not specified, using default:{style:#} {italic}{DEFAULT_APP_USERNAME}{italic:#}",
                     style = Style::new()
@@ -192,7 +215,7 @@ impl AppCommands {
                 );
             }
 
-            if args.password.is_none() {
+            if matches!(credentials, CrtCredentials::Basic { .. }) && args.password.is_none() {
                 eprintln!(
                     "{style}warning: Creatio password is not specified, using default:{style:#} {italic}{DEFAULT_APP_USERNAME}{italic:#}",
                     style = Style::new()
@@ -293,7 +316,91 @@ impl AppCommandArgs {
         self.url = app_config.url;
         self.username = app_config.username;
         self.password = app_config.password;
+        self.oauth_url = app_config.oauth_url;
+        self.oauth_client_id = app_config.oauth_client_id;
+        self.oauth_client_secret = app_config.oauth_client_secret;
         self.insecure = app_config.insecure.unwrap_or_default();
         self.net_framework = app_config.net_framework.unwrap_or_default();
+    }
+
+    pub fn get_credentials(&self) -> Result<CrtCredentials, CommandDynError> {
+        return match (self.username.is_some(), self.oauth_client_id.is_some()) {
+            (true, true) => {
+                eprintln!(
+                    "{style}warning: both username and oauth_client_id options are specified, continuing with username:password authentication",
+                    style = Style::new()
+                        .fg_color(Some(Color::Ansi(AnsiColor::BrightYellow)))
+                        .dimmed(),
+                );
+
+                get_basic_credentials(self)
+            }
+            (false, true) => get_oauth_credentials(self),
+            _ => get_basic_credentials(self),
+        };
+
+        fn get_basic_credentials(
+            _self: &AppCommandArgs,
+        ) -> Result<CrtCredentials, CommandDynError> {
+            let username = if let Some(username) = &_self.username {
+                username
+            } else {
+                DEFAULT_APP_USERNAME
+            };
+
+            let password = if let Some(password) = &_self.password {
+                password
+            } else {
+                DEFAULT_APP_PASSWORD
+            };
+
+            Ok(CrtCredentials::new(&_self.url, username, password))
+        }
+
+        fn get_oauth_credentials(
+            _self: &AppCommandArgs,
+        ) -> Result<CrtCredentials, CommandDynError> {
+            if _self.oauth_url.is_none() || _self.oauth_client_secret.is_none() {
+                let bold = Style::new().bold();
+                let bold_underline = Style::new().bold().underline();
+                let green = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+
+                eprintln!(
+                    "{red_bold}error:{red_bold:#} the following required arguments were not provided:",
+                    red_bold = Style::new()
+                        .fg_color(Some(Color::Ansi(AnsiColor::Red)))
+                        .bold(),
+                );
+
+                if _self.oauth_url.is_none() {
+                    eprintln!("  {green}--oauth-url <OAUTH_URL>{green:#}");
+                }
+
+                if _self.oauth_client_secret.is_none() {
+                    eprintln!("  {green}--oauth-client-secret <OAUTH_CLIENT_SECRET>{green:#}");
+                }
+
+                eprintln!();
+                eprintln!(
+                    "{bold_underline}Usage:{bold_underline:#} {bold}crtcli app{bold:#} <URL/APP> {bold}--oauth-url{bold:#} <OAUTH_URL> {bold}--oauth-client-id{bold:#} <OAUTH_CLIENT_ID> {bold}--oauth-client-secret{bold:#} <OAUTH_CLIENT_SECRET> [COMMAND]"
+                );
+                eprintln!();
+                eprintln!("For more information, try '{bold}crtcli app --help{bold:#}'.");
+
+                return Err(CommandHandledError(ExitCode::FAILURE).into());
+            }
+
+            // Safe, should be checked in previous methods
+            let oauth_url = _self.oauth_url.as_ref().unwrap();
+            let client_id = _self.oauth_client_id.as_ref().unwrap();
+            let client_secret = _self.oauth_client_secret.as_ref().unwrap();
+
+            Ok(CrtCredentials::new_oauth(
+                &_self.url,
+                oauth_url,
+                client_id,
+                client_secret,
+            ))
+        }
     }
 }

--- a/src/crtcli/src/cmd/workspace_config.rs
+++ b/src/crtcli/src/cmd/workspace_config.rs
@@ -11,6 +11,9 @@ pub struct WorkspaceAppConfig {
     pub url: String,
     pub username: Option<String>,
     pub password: Option<String>,
+    pub oauth_url: Option<String>,
+    pub oauth_client_id: Option<String>,
+    pub oauth_client_secret: Option<String>,
     pub insecure: Option<bool>,
     pub net_framework: Option<bool>,
 }


### PR DESCRIPTION
This PR introduces OAuth 2.0 authentication support for crtcli app commands. It also adds a `--force-new-session` option to explicitly invalidate session cache.

To use OAuth authentication instead of username and password, omit the username and password arguments and, instead, provide the `oauth_*` options. 
_(Note: If both username/password and OAuth credentials are provided, username/password authentication will take precedence.)_

Example of using crtcli with OAuth 2.0:
```sh
crtcli app https://myinstance.creatio.com \
  --oauth-url https://myinstance-is.creatio.com \
  --oauth-client-id "A1B2C3D4..." \
  --oauth-client-secret "X9Y8Z7W6..." \
  pkgs
```

Please check the updated README.md for more usage examples.