### PR TITLE
feat: commands and options aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
  - Added `app tunnel` command which allows to establish TCP tunnels via the Creatio instance ([#21](https://github.com/heabijay/crtcli/pull/21))
 
- - Stdin option to `app pkg install` using '@-' or '-' as filename ([#22](https://github.com/heabijay/crtcli/pull/22))
+ - Added stdin option to `app pkg install` using '@-' or '-' as filename ([#22](https://github.com/heabijay/crtcli/pull/22))
 
  - Implemented OAuth 2 authentication support to `crtcli app` commands ([#23](https://github.com/heabijay/crtcli/pull/23))
 
- - Flag `--force-new-session` for `crtcli app` commands just in case you need to invalidate session cache before executing ([#23](https://github.com/heabijay/crtcli/pull/23))
+ - Added flag `--force-new-session` for `crtcli app` commands just in case you need to invalidate session cache before executing ([#23](https://github.com/heabijay/crtcli/pull/23))
+
+ - Added aliases for some commands, subcommands, and options (e.g., `crtcli a p d` instead of `crtcli app pkg download`) ([#24](https://github.com/heabijay/crtcli/pull/24))
 
 
 ## [0.1.3](https://github.com/heabijay/crtcli/releases/tag/v0.1.3) (2025-03-25)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Commands to interact with Creatio application instance.
 
 Please check [dotenv (.env) files](#dotenv-env-files) and [workspace.crtcli.toml](#workspacecrtclitoml) for simplified commands usage.
 
+**Aliases:** `a` (full command: `crtcli a ...`)
+
 **Arguments:**
 
 - `<URL/APP>` (required) (env: `CRTCLI_APP_URL`) — The base URL of Creatio instance or an app alias defined in [workspace.crtcli.toml](#workspacecrtclitoml). 
@@ -103,7 +105,7 @@ Please check [dotenv (.env) files](#dotenv-env-files) and [workspace.crtcli.toml
 
 - `--insecure | -i` (env: `CRTCLI_APP_INSECURE`) — Bypass SSL certificate verification. Use with caution, primarily for development or testing environments.
 
-- `--net-framework` (env: `CRTCLI_APP_NETFRAMEWORK`) — Use .NET Framework (IIS) Creatio compatibility 
+- `--net-framework | --nf` (env: `CRTCLI_APP_NETFRAMEWORK`) — Use .NET Framework (IIS) Creatio compatibility 
 
   By default, crtcli primary uses .NET Core / .NET (Kestrel) API routes to operate with remote. However, some features like "app restart" works by different API routes in both platforms.
 
@@ -236,6 +238,8 @@ Commands to manipulate with packages in Creatio.
 
 Many of these commands will attempt to infer the target package name from the current working directory if it's a package folder (contains a descriptor.json file).
 
+**Aliases:** `p` (full command: `crtcli app p ...` or `crtcli a p ...`)
+
 
 ### app pkg compile
 
@@ -263,6 +267,8 @@ For example current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/U
 ### app pkg download
 
 Downloads packages from the Creatio instance as a zip archive.
+
+**Aliases:** `d`, `dl` (full command: `crtcli app pkg d ...` or `crtcli a p d ...`)
 
 **Arguments:**
 
@@ -373,6 +379,8 @@ For example current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/U
 ### app pkg install
 
 Installs a package archive (.zip or .gz) into the Creatio instance.
+
+**Aliases:** `i` (full command: `crtcli app i ...` or `crtcli a i ...`)
 
 **Arguments:**
 
@@ -693,6 +701,8 @@ Important: If your Creatio instance is running on .NET Framework (IIS), you must
 
 Sends authenticated HTTP requests to the Creatio instance, similar to curl.
 
+**Aliases:** `req` (full command: `crtcli app req ...` or `crtcli a req ...`)
+
 **Arguments:**
 
 - `<METHOD>` (required) — HTTP method (e.g., GET, POST, PUT, DELETE, etc.).
@@ -921,6 +931,8 @@ https://github.com/user-attachments/assets/fa55b89e-2d71-46e9-9c20-de4a300f28e7
 
 Commands for working with Creatio package files (.zip, .gz) or package folders locally, without interacting with a Creatio instance.
 
+**Aliases:** `p` (full command: `crtcli p ...` or `crtcli p ...`)
+
 
 ### pkg apply
 
@@ -979,6 +991,8 @@ Included Paths:
 
 Excluded: Hidden folders and files (names starting with .).
 
+**Aliases:** `p` (full command: `crtcli pkg p ...` or `crtcli p p ...`)
+
 **Arguments:**
 
 - `<PACKAGE_FOLDERS>` (required) — Source folders containing the package files to be packaged.
@@ -999,7 +1013,7 @@ Excluded: Hidden folders and files (names starting with .).
 
 - `--format <FORMAT>` — Archive format.
 
-    Possible values: gzip, zip    
+    Possible values: gzip (gz), zip    
 
     Defaults: zip
 
@@ -1025,6 +1039,8 @@ For example current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/U
 ### pkg unpack
 
 Extract a single package from a package archive (.zip or .gz). To extract multiple packages from a zip archive, use [pkg unpack-all](#pkg-unpack-all).
+
+**Aliases:** `u` (full command: `crtcli pkg u ...` or `crtcli p u ...`)
 
 **Arguments:**
 

--- a/src/crtcli/src/cmd/app/mod.rs
+++ b/src/crtcli/src/cmd/app/mod.rs
@@ -88,7 +88,11 @@ pub struct AppCommandArgs {
     ///
     /// By default, crtcli primary uses .NET Core / .NET (Kestrel) API routes to operate with remote.
     /// However, some features like "app restart" works by different API routes in both platforms.
-    #[arg(long = "net-framework", env = "CRTCLI_APP_NETFRAMEWORK")]
+    #[arg(
+        long = "net-framework",
+        visible_alias = "nf",
+        env = "CRTCLI_APP_NETFRAMEWORK"
+    )]
     net_framework: bool,
 
     /// Forcefully revoke the cached session and use a new one
@@ -119,6 +123,7 @@ pub enum AppCommands {
     InstallLog(install_log::InstallLogCommand),
 
     /// Commands to manipulate with packages in Creatio
+    #[clap(visible_alias = "p")]
     Pkg {
         #[command(subcommand)]
         command: pkg::PkgCommands,
@@ -130,6 +135,7 @@ pub enum AppCommands {
     /// Restarts the Creatio application
     Restart(restart::RestartCommand),
 
+    #[clap(visible_alias = "req")]
     /// Sends authenticated HTTP requests to the Creatio instance, similar to curl
     Request(request::RequestCommand),
 

--- a/src/crtcli/src/cmd/app/pkg/mod.rs
+++ b/src/crtcli/src/cmd/app/pkg/mod.rs
@@ -31,6 +31,7 @@ pub enum PkgCommands {
     Compile(compile_pkg::CompilePkgCommand),
 
     /// Downloads packages from the Creatio instance as a zip archive
+    #[clap(visible_aliases = &["d", "dl"])]
     Download(download_pkg::DownloadPkgCommand),
 
     /// Commands/aliases to simplify manipulate with package insides File System Development mode (FSD) location
@@ -40,6 +41,7 @@ pub enum PkgCommands {
     },
 
     /// Installs a package archive (.zip or .gz) into the Creatio instance
+    #[clap(visible_alias = "i")]
     Install(install_pkg::InstallPkgCommand),
 
     /// Print installed package information by Package UId

--- a/src/crtcli/src/cmd/cli.rs
+++ b/src/crtcli/src/cmd/cli.rs
@@ -1,4 +1,3 @@
-use crate::cmd::app::{AppCommandArgs, AppCommands};
 use clap::{Command, CommandFactory, Parser, Subcommand};
 use regex::Regex;
 use std::borrow::Cow;
@@ -70,10 +69,10 @@ enum Commands {
     /// `crtcli app dev restart` -- Restarts Creatio instance using the 'dev' app alias.
     /// `crtcli app pkg download CrtBase,CrtCore` -- Downloads CrtBase and CrtCore packages from Creatio to single zip file.
     /// `crtcli app pkg push` -- Immediate packs current folder as package and installs it to Creatio instance.
-    #[clap(verbatim_doc_comment)]
+    #[clap(verbatim_doc_comment, visible_alias = "a")]
     App {
         #[command(flatten)]
-        args: AppCommandArgs,
+        args: crate::cmd::app::AppCommandArgs,
 
         #[command(subcommand)]
         command: crate::cmd::app::AppCommands,
@@ -86,7 +85,7 @@ enum Commands {
     /// Example use cases:
     /// `crtcli pkg pack .` -- Packs current folder as package to single gzip/zip file.
     /// `crtcli pkg apply . --apply-localization-cleanup 'en-US'` -- Deletes all localization files in current folder as package except en-US.
-    #[clap(verbatim_doc_comment)]
+    #[clap(verbatim_doc_comment, visible_alias = "p")]
     Pkg {
         #[command(subcommand)]
         command: crate::cmd::pkg::PkgCommands,
@@ -103,7 +102,10 @@ impl CliCommand for Commands {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn run_app_command(args: AppCommandArgs, command: AppCommands) -> CommandResult {
+async fn run_app_command(
+    args: crate::cmd::app::AppCommandArgs,
+    command: crate::cmd::app::AppCommands,
+) -> CommandResult {
     command.run(args).await
 }
 

--- a/src/crtcli/src/cmd/pkg/mod.rs
+++ b/src/crtcli/src/cmd/pkg/mod.rs
@@ -15,9 +15,11 @@ pub enum PkgCommands {
     Apply(apply::ApplyCommand),
 
     /// Creates a package archive (.zip or .gz) from package folders
+    #[clap(visible_alias = "p")]
     Pack(pack::PackCommand),
 
     /// Extract a single package from a package archive (.zip or .gz)
+    #[clap(visible_alias = "u")]
     Unpack(unpack::UnpackCommand),
 
     /// Extract all packages from a zip archive

--- a/src/crtcli/src/cmd/pkg/pack.rs
+++ b/src/crtcli/src/cmd/pkg/pack.rs
@@ -29,6 +29,7 @@ pub struct PackCommand {
 
 #[derive(Debug, Clone, Eq, PartialEq, ValueEnum)]
 pub enum PackFormat {
+    #[value(alias = "gz")]
     Gzip,
     Zip,
 }


### PR DESCRIPTION
Now you can use additional aliases for some commands and options:

* `app` — `a` (e.g., `crtcli a pkgs` instead of `crtcli app pkgs`).
    * `--net-framework` flag — `--nf` (e.g., `crtcli a --nf restart` instead of `crtcli app --net-framework restart`).
    * `pkg` — `p` (e.g., `crtcli a p lock` instead of `crtcli app pkg lock`).
        * `download` — `d` or `dl` (e.g., `crtcli a p d` or `crtcli a p dl` instead of `crtcli app pkg download`).
        * `install` — `i` (e.g., `crtcli a p i Package.zip` instead of `crtcli app pkg install Package.zip`).
    * `request` — `req` (e.g., `crtcli a req GET /` instead of `crtcli app request GET /`).
* `pkg` — `p` (e.g., `crtcli p apply .` instead of `crtcli pkg apply .`).
* `pack` — `p` (e.g., `crtcli p p .` instead of `crtcli pkg pack .`).
    * `gzip` pack format — `gz` (e.g., `crtcli p p . --format gz` instead of `crtcli pkg pack . --format gzip`).
* `unpack` — `u` (e.g., `crtcli p u Package.zip` instead of `crtcli pkg unpack Package.zip`).

**Example:**
`crtcli a p fs pull` is equivalent to `crtcli app pkg fs pull`
`crtcli a p push` is equivalent to `crtcli app pkg push`