### PR TITLE
feat(pkg-apply): bom normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ This is useful for standardizing package structure, cleaning up localization fil
 
 **Transforms (also options):**
 
-- `--apply-sorting | -S <true/false>` — Sorts the contents of specific files within the package. This is useful when you work with any VCS cause it prevents you from check some inconsistent diffs.
+- `--apply-sorting | -S <true/false>` — Sorts the contents of specific files within the package. This is useful when you work with any VCS cause it prevents you from check some inconsistent diffs. (Recommended)
 
     _Affects:_
   - descriptor.json
@@ -962,11 +962,24 @@ This is useful for standardizing package structure, cleaning up localization fil
   - Data/**/Localization/*.json
   - Files/*.csproj
 
-- `--apply-localization-cleanup | -L <EXCEPT-LOCALIZATIONS>` —  Removes localization files except for the specified cultures (comma-separated list).
+- `--apply-localization-cleanup | -L <EXCEPT-LOCALIZATIONS>` —  Removes localization files except for the specified cultures (comma-separated list). (Recommended)
 
     _Affects_:
   - Data/**/Localization/data.*.json
   - Resources/**/resource.*.xml
+  
+- `--apply-bom-normalization <add/remove>` — Normalizes a Byte Order Mark (BOM) in package schema files (.json / .xml) by adding or removing BOM bytes.
+
+    _Affects_:
+  - descriptor.json
+  - Assemblies/**/*.json
+  - Data/**/*.json
+  - Data/**/Localization/*.json
+  - Resources/**/resource.*.xml
+  - Schemas/**/descriptor.json
+  - Schemas/**/metadata.json
+  - Schemas/**/properties.json
+  - SqlSchemas/**/descriptor.json
 
 \* Check [package.crtcli.toml](#packagecrtclitoml) to configure default apply transforms.
 
@@ -1169,6 +1182,8 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
 
 - `apply.localization_cleanup = <except-localizations>` — Enable/disable localization cleanup transform by default in [pkg apply](#pkg-apply) command.
 
+- `apply.bom_normalization = <add/remove>` — Normalizes a Byte Order Mark (BOM) in package schema files by default in [pkg apply](#pkg-apply) command.
+
 **Examples:**
 
 1. For example, current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/UsrPackage' which is package folder inside in Creatio.
@@ -1213,7 +1228,7 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
 - `apps.<alias>.username` — (Optional) The username for authentication.
 - `apps.<alias>.password` — (Optional) The password for authentication.
 - `apps.<alias>.insecure` — (Optional) Set to `true` to disable SSL certificate validation.
-- `apps.<alias>.net_framework` — (Optional) Set to `true` if your Creatio instance is running on .NET Framework (IIS).
+- `apps.<alias>.net_framework` | `apps.<alias>.netframework` — (Optional) Set to `true` if your Creatio instance is running on .NET Framework (IIS).
 
 For OAuth 2.0 authentication (instead of username and password):
 

--- a/src/crtcli/Cargo.toml
+++ b/src/crtcli/Cargo.toml
@@ -17,25 +17,25 @@ clap_complete = "4.5.55"
 dotenvy = "0.15.7"
 flate2 = "1.1.2"
 futures = "0.3.31"
-hyper-util = "0.1.15"
+hyper-util = "0.1.16"
 indexmap = { version =  "2.10.0", features = ["serde"] }
 indicatif = "0.18"
-quick-xml = "0.38"
-rustls = { version = "0.23.29", features = ["ring"] }
+quick-xml = "0.38.1"
+rustls = { version = "0.23.31", features = ["ring"] }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = { version = "1.0.140", features = ["preserve_order"] }
+serde_json = { version = "1.0.142", features = ["preserve_order"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["macros"] }
+tokio = { version = "1.47.1", features = ["macros"] }
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7.15", features = ["io", "io-util"] }
-toml = "0.9.2"
+tokio-util = { version = "0.7.16", features = ["io", "io-util"] }
+toml = "0.9.4"
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 zip = "4.3.0"
 
 [dependencies.clap]
-version = "4.5.41"
+version = "4.5.42"
 features = ["derive", "env", "suggestions", "usage"]
 
 [dependencies.time]

--- a/src/crtcli/src/pkg/converters/bom_normalization.rs
+++ b/src/crtcli/src/pkg/converters/bom_normalization.rs
@@ -1,0 +1,79 @@
+use crate::pkg::converters::PkgFileConverter;
+use crate::pkg::json_wrappers::*;
+use crate::pkg::paths::*;
+use crate::utils::bom;
+use clap::ValueEnum;
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, Deserialize, ValueEnum)]
+pub enum BomNormalizationMode {
+    /// Adds Byte Order Mark bytes to files if not present.
+    #[serde(rename = "add")]
+    Add,
+
+    /// Removes Byte Order Mark bytes from files if present.
+    #[serde(rename = "remove")]
+    Remove,
+}
+
+pub struct BomNormalizationPkgFileConverter {
+    mode: BomNormalizationMode,
+}
+
+impl BomNormalizationPkgFileConverter {
+    pub fn new(mode: BomNormalizationMode) -> Self {
+        Self { mode }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum BomNormalizationPkgFileConverterError {}
+
+impl PkgFileConverter for BomNormalizationPkgFileConverter {
+    type Error = BomNormalizationPkgFileConverterError;
+
+    fn convert(
+        &self,
+        filename: &str,
+        mut content: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        if self.is_applicable(filename) {
+            match self.mode {
+                BomNormalizationMode::Add => {
+                    if !bom::is_bom(&content) {
+                        content.splice(0..0, bom::BOM_CHAR_BYTES.iter().cloned());
+
+                        return Ok(Some(content));
+                    }
+                }
+                BomNormalizationMode::Remove => {
+                    if bom::is_bom(&content) {
+                        let content_out = Vec::from(bom::trim_bom(&content));
+
+                        return Ok(Some(content_out));
+                    }
+                }
+            }
+        }
+
+        Ok(Some(content))
+    }
+
+    fn is_applicable(&self, filename: &str) -> bool {
+        if filename.starts_with(FILES_FOLDER) {
+            return false;
+        }
+
+        PKG_DESCRIPTOR_FILE == filename
+            || PKG_ASSEMBLIES_DESCRIPTOR_PATH_REGEX.is_match(filename)
+            || PKG_DATA_DESCRIPTOR_PATH_REGEX.is_match(filename)
+            || PKG_DATA_DATA_PATH_REGEX.is_match(filename)
+            || PKG_DATA_LCZ_DATA_PATH_REGEX.is_match(filename)
+            || PKG_RESOURCE_PATH_REGEX.is_match(filename)
+            || PKG_SCHEMAS_DESCRIPTOR_PATH_REGEX.is_match(filename)
+            || PKG_SCHEMAS_METADATA_PATH_REGEX.is_match(filename)
+            || PKG_SCHEMAS_PROPERTIES_PATH_REGEX.is_match(filename)
+            || PKG_SQLSCRIPTS_DESCRIPTOR_PATH_REGEX.is_match(filename)
+    }
+}

--- a/src/crtcli/src/pkg/converters/mod.rs
+++ b/src/crtcli/src/pkg/converters/mod.rs
@@ -7,6 +7,9 @@ pub use combined_converter::*;
 mod localization_cleanup;
 pub use localization_cleanup::*;
 
+mod bom_normalization;
+pub use bom_normalization::*;
+
 pub trait PkgFileConverter {
     type Error: std::error::Error + Send + Sync + 'static;
 

--- a/src/crtcli/src/pkg/json-wrappers/mod.rs
+++ b/src/crtcli/src/pkg/json-wrappers/mod.rs
@@ -12,3 +12,12 @@ pub use pkg_data_descriptor::*;
 
 mod pkg_resource;
 pub use pkg_resource::*;
+
+mod pkg_schemas_descriptor;
+pub use pkg_schemas_descriptor::*;
+
+mod pkg_sqlscripts_descriptor;
+pub use pkg_sqlscripts_descriptor::*;
+
+mod pkg_assemblies_descriptor;
+pub use pkg_assemblies_descriptor::*;

--- a/src/crtcli/src/pkg/json-wrappers/pkg_assemblies_descriptor.rs
+++ b/src/crtcli/src/pkg/json-wrappers/pkg_assemblies_descriptor.rs
@@ -1,0 +1,10 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+pub static PKG_ASSEMBLIES_DESCRIPTOR_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^Assemblies{sep}.+?{sep}descriptor.json$",
+        sep = regex::escape(std::path::MAIN_SEPARATOR_STR)
+    ))
+    .expect("failed to compile regex for package assemblies descriptor path regex")
+});

--- a/src/crtcli/src/pkg/json-wrappers/pkg_schemas_descriptor.rs
+++ b/src/crtcli/src/pkg/json-wrappers/pkg_schemas_descriptor.rs
@@ -1,0 +1,26 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+pub static PKG_SCHEMAS_DESCRIPTOR_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^Schemas{sep}.+?{sep}descriptor.json$",
+        sep = regex::escape(std::path::MAIN_SEPARATOR_STR)
+    ))
+    .expect("failed to compile regex for package schemas descriptor path regex")
+});
+
+pub static PKG_SCHEMAS_METADATA_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^Schemas{sep}.+?{sep}metadata.json$",
+        sep = regex::escape(std::path::MAIN_SEPARATOR_STR)
+    ))
+    .expect("failed to compile regex for package schemas metadata path regex")
+});
+
+pub static PKG_SCHEMAS_PROPERTIES_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^Schemas{sep}.+?{sep}properties.json$",
+        sep = regex::escape(std::path::MAIN_SEPARATOR_STR)
+    ))
+    .expect("failed to compile regex for package schemas properties path regex")
+});

--- a/src/crtcli/src/pkg/json-wrappers/pkg_sqlscripts_descriptor.rs
+++ b/src/crtcli/src/pkg/json-wrappers/pkg_sqlscripts_descriptor.rs
@@ -1,0 +1,10 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+pub static PKG_SQLSCRIPTS_DESCRIPTOR_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^SqlScripts{sep}.+?{sep}descriptor.json$",
+        sep = regex::escape(std::path::MAIN_SEPARATOR_STR)
+    ))
+    .expect("failed to compile regex for package sqlscripts descriptor path regex")
+});


### PR DESCRIPTION
In the `crtcli pkg apply` command, a new transform was added: `--apply-bom-normalization <add/remove>`. This transform normalizes a Byte Order Mark (BOM) in package schema files (.json / .xml) by adding or removing BOM bytes.

You may need this transform if there are differences in UTF-8 encoding between multiple Creatio environments and IDEs, though this is rare.