### PR TITLE
feat(app-pkg-download): support output to stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Downloads packages from the Creatio instance as a zip archive.
 
 **Options:**
 
-- `--output | -o <PATH>` — Output path where the downloaded package archive will be saved.
+- `--output | -o <PATH>` — Output path where the downloaded package archive will be saved. Use '@-' or '-' value to write data to stdout.
 
   If a directory is provided: The archive will be saved there with an auto-generated name.
 
@@ -386,7 +386,7 @@ Installs a package archive (.zip or .gz) into the Creatio instance.
 
 **Arguments:**
 
-- `<FILEPATH>` (required) — Path to the package archive file. (Use '@-' or '-' value to read data from standard input)
+- `<FILEPATH>` (required) — Path to the package archive file. (Use '@-' or '-' value to read data from stdin)
 
 **Options:**
 
@@ -715,7 +715,7 @@ Sends authenticated HTTP requests to the Creatio instance, similar to curl.
 
 - `--anonymous | -a` — Send the request without authentication.
 
-- `--data | -d <DATA>` — Request body data (for methods like POST). Use '@-' or '-' value to read data from standard input.
+- `--data | -d <DATA>` — Request body data (for methods like POST). Use '@-' or '-' value to read data from stdin.
 
 - `--header | -H <HEADER>` — Add a custom header to the request (format: Key: Value). The default Content-Type is application/json.
 

--- a/src/crtcli/Cargo.toml
+++ b/src/crtcli/Cargo.toml
@@ -13,33 +13,33 @@ anstyle = "1.0.11"
 async-trait = "0.1.89"
 bincode = "2.0.1"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-clap_complete = "4.5.57"
+clap_complete = "4.5.58"
 dotenvy = "0.15.7"
 flate2 = "1.1.2"
 futures = "0.3.31"
-hyper-util = "0.1.16"
-indexmap = { version =  "2.11.1", features = ["serde"] }
+hyper-util = "0.1.17"
+indexmap = { version =  "2.11.4", features = ["serde"] }
 indicatif = "0.18"
 quick-xml = "0.38.3"
-rustls = { version = "0.23.31", features = ["ring"] }
-regex = "1.11.2"
-serde = { version = "1.0.223", features = ["derive"] }
+rustls = { version = "0.23.32", features = ["ring"] }
+regex = "1.11.3"
+serde = { version = "1.0.227", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 thiserror = "2.0.16"
-tokio = { version = "1.47.1", features = ["macros"] }
-tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
+tokio = { version = "1.47.1", features = ["macros", "io-std"] }
+tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7.16", features = ["io", "io-util"] }
-toml = "0.9.5"
+toml = "0.9.7"
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 zip = "5.1.1"
 
 [dependencies.clap]
-version = "4.5.47"
+version = "4.5.48"
 features = ["derive", "env", "suggestions", "usage"]
 
 [dependencies.time]
-version = "0.3.43"
+version = "0.3.44"
 features = ["formatting", "local-offset", "macros"]
 
 [dependencies.reqwest]

--- a/src/crtcli/src/cmd/app/pkg/install_pkg.rs
+++ b/src/crtcli/src/cmd/app/pkg/install_pkg.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 #[derive(Args, Debug)]
 pub struct InstallPkgCommand {
-    /// Path to the package archive file (Use '@-' or '-' value to read data from standard input)
+    /// Path to the package archive file (Use '@-' or '-' value to read data from stdin)
     #[arg(value_hint = clap::ValueHint::FilePath)]
     filepath: PathBuf,
 

--- a/src/crtcli/src/cmd/app/pkgs.rs
+++ b/src/crtcli/src/cmd/app/pkgs.rs
@@ -1,6 +1,7 @@
 use crate::app::CrtClient;
 use crate::cmd::app::AppCommand;
 use crate::cmd::cli::CommandResult;
+use anstream::stdout;
 use anstyle::Style;
 use async_trait::async_trait;
 use clap::Args;
@@ -27,11 +28,13 @@ impl AppCommand for PkgsCommand {
             }
         }
 
-        eprintln!(
-            "{style}Total: {} packages{style:#}",
-            packages.len(),
-            style = Style::new().underline()
-        );
+        if stdout().is_terminal() {
+            eprintln!(
+                "{style}Total: {} packages{style:#}",
+                packages.len(),
+                style = Style::new().underline()
+            );
+        }
 
         Ok(())
     }

--- a/src/crtcli/src/cmd/app/request.rs
+++ b/src/crtcli/src/cmd/app/request.rs
@@ -28,7 +28,7 @@ pub struct RequestCommand {
     #[arg(short, long)]
     anonymous: bool,
 
-    /// Request body data (for methods like POST) (Use '@-' or '-' value to read data from standard input)
+    /// Request body data (for methods like POST) (Use '@-' or '-' value to read data from stdin)
     #[arg(short, long, value_hint = clap::ValueHint::Other)]
     data: Option<String>,
 

--- a/src/crtcli/src/cmd/cli.rs
+++ b/src/crtcli/src/cmd/cli.rs
@@ -58,7 +58,7 @@ enum Commands {
     /// Commands to interact with Creatio application instance
     ///
     /// This is the collection of subcommands that are related to concrete Creatio instance.
-    /// You should specify Creatio connection parameters like URL, USERNAME, PASSWORD through command arguments
+    /// You should specify Creatio connection parameters like URL, USERNAME, PASSWORD through command arguments,
     /// or you could set ENV variables (as well as create .env file) for better UX.
     ///
     /// You can also use app aliases defined in workspace.crtcli.toml config file by specifying

--- a/src/crtcli/src/cmd/pkg/unpack.rs
+++ b/src/crtcli/src/cmd/pkg/unpack.rs
@@ -35,7 +35,7 @@ pub struct UnpackCommand {
 #[derive(Error, Debug)]
 enum UnpackCommandError {
     #[error("invalid package filename in path")]
-    InvalidPackageFilename(),
+    InvalidPackageFilename,
 
     #[error("failed to read the package file: {0}")]
     ReadPackageFile(#[from] std::io::Error),
@@ -58,7 +58,7 @@ enum UnpackCommandError {
     #[error(
         "multiple files found in zip package bundle, please specify file using -p argument or use 'unpack-all' command"
     )]
-    MultipleFilesInZipPackage(),
+    MultipleFilesInZipPackage,
 }
 
 impl CliCommand for UnpackCommand {
@@ -69,9 +69,9 @@ impl CliCommand for UnpackCommand {
                 let filename = self
                     .package_filepath
                     .file_stem()
-                    .ok_or(UnpackCommandError::InvalidPackageFilename())?
+                    .ok_or(UnpackCommandError::InvalidPackageFilename)?
                     .to_str()
-                    .ok_or(UnpackCommandError::InvalidPackageFilename())?;
+                    .ok_or(UnpackCommandError::InvalidPackageFilename)?;
 
                 crate::cmd::utils::get_next_filename_if_exists(PathBuf::from(".").join(filename))
             }
@@ -104,7 +104,7 @@ impl CliCommand for UnpackCommand {
 
         let gzip_result: Option<_> = match &zip_result {
             Err(ExtractSingleZipPackageError::MultiplePackageInZipFile) => {
-                return Err(UnpackCommandError::MultipleFilesInZipPackage().into());
+                return Err(UnpackCommandError::MultipleFilesInZipPackage.into());
             }
             Err(ExtractSingleZipPackageError::OpenZipFileForReading(ZipError::InvalidArchive(
                 _,

--- a/src/crtcli/src/cmd/pkg/unpack_all.rs
+++ b/src/crtcli/src/cmd/pkg/unpack_all.rs
@@ -26,7 +26,7 @@ pub struct UnpackAllCommand {
 #[derive(Error, Debug)]
 enum UnpackAllCommandError {
     #[error("invalid package filename in path")]
-    InvalidPackageFilename(),
+    InvalidPackageFilename,
 
     #[error("file access error: {0}")]
     FileAccess(#[from] std::io::Error),
@@ -43,9 +43,9 @@ impl CliCommand for UnpackAllCommand {
                 let filename = self
                     .package_filepath
                     .file_stem()
-                    .ok_or(UnpackAllCommandError::InvalidPackageFilename())?
+                    .ok_or(UnpackAllCommandError::InvalidPackageFilename)?
                     .to_str()
-                    .ok_or(UnpackAllCommandError::InvalidPackageFilename())?;
+                    .ok_or(UnpackAllCommandError::InvalidPackageFilename)?;
 
                 crate::cmd::utils::get_next_filename_if_exists(PathBuf::from(".").join(filename))
             }


### PR DESCRIPTION
Now you can use the value `@-` or `-` with the `--output | -o` option in the `app pkg download` command to write the output package to stdout (standard output).

For example, you can use this to simply copy a package from one app to another:

```sh
crtcli app dev pkg download --output - | crtcli app prod pkg install -
```

e.g.

```sh
crtcli a p d -o - | crtcli a p i -
```