### PR TITLE
bugfix(install-log-watcher): app pkg install could stuck in endless waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
  - Replaced the `--data-stdin | -D` option with the '-' value of the `--data | -d` option in the `app request` command ([#14](https://github.com/heabijay/crtcli/pull/14))
 
- - Refactored `app`-based commands to use the tokio async runtime, which should improve install log pooling ([#16](https://github.com/heabijay/crtcli/pull/16))
+ - Refactored `app`-based commands to use the tokio async runtime, which should improve install log polling ([#16](https://github.com/heabijay/crtcli/pull/16))
 
  - Simplified the compile and restart options in `app pkg fs push`; also, `app pkg fs push -r` now works without the `-c` option ([#17](https://github.com/heabijay/crtcli/pull/17))
 

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Installs a package archive (.zip or .gz) into the Creatio instance.
   );
   ```
   
-- `--disable-install-log-pooling` — Disables the display of the installation log.
+- `--disable-install-log-polling` — Disables the display of the installation log.
 
   
 \* (sql) — Requires an installed sql runner package in Creatio that is supported by crtcli. Please check [app sql](#app-sql) command documentation. 

--- a/src/crtcli/Cargo.toml
+++ b/src/crtcli/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 anstream = "0.6.20"
-anstyle = "1.0.11"
+anstyle = "1.0.13"
 async-trait = "0.1.89"
 bincode = "2.0.1"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
@@ -23,9 +23,9 @@ indicatif = "0.18"
 quick-xml = "0.38.3"
 rustls = { version = "0.23.32", features = ["ring"] }
 regex = "1.11.3"
-serde = { version = "1.0.227", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
-thiserror = "2.0.16"
+thiserror = "2.0.17"
 tokio = { version = "1.47.1", features = ["macros", "io-std"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7.16", features = ["io", "io-util"] }

--- a/src/crtcli/src/cmd/app/tunnel.rs
+++ b/src/crtcli/src/cmd/app/tunnel.rs
@@ -245,7 +245,7 @@ impl AppCommand for TunnelCommand {
             let start_time = Instant::now();
             let refresh_interval = Duration::from_millis(500);
 
-            let cancellation_token = start_pooling_cancellation_token();
+            let cancellation_token = start_polling_cancellation_token();
             let mut stderr = anstream::stderr();
 
             loop {
@@ -364,7 +364,7 @@ impl AppCommand for TunnelCommand {
             let _ = terminal::disable_raw_mode();
         }
 
-        fn start_pooling_cancellation_token() -> CancellationToken {
+        fn start_polling_cancellation_token() -> CancellationToken {
             let mut event_stream = EventStream::new();
             let cancellation_token = CancellationToken::new();
 


### PR DESCRIPTION
Fixes a bug where a log fetching error caused an endless wait for the installation status, as it prematurely resolved the waiting process.

You will now receive the final installation result (success/failed) faster, with an accompanying spinner for the final log fetching process.