### PR TITLE
feat(pkg-apply): improve resource.*.xml sorting by multiple str comparers

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,16 @@ This is useful for standardizing package structure, cleaning up localization fil
   - Resources/**/resource.*.xml
   - Files/*.csproj
 
+- `--apply-sorting-comparer <COMPARER>` — Configures the sorting comparer for the `--apply-sorting | -S` transform, which will be used to sort strings.
+
+  This is necessary for sorting `Resources/**/resource.*.xml` files when working on Creatio with different database types.
+
+  Possible values:
+  - `alnum` (aliases: `psql`, `postgresql`) (default) — An alphanumeric comparer, pretending to be equivalent to PostgreSQL collation comparing/ordering. This means that it ignores non-alphanumeric characters when comparing. This option is the best when your primary Creatio database is PostgreSQL.
+  - `std` (aliases: `standard`, `mssql`) — A standard comparer, which uses all characters in a string and compares bytes byte by byte. This option is the best when your primary Creatio database is Microsoft SQL Server.
+
+  Defaults: `alnum`
+
 - `--apply-localization-cleanup | -L <EXCEPT-LOCALIZATIONS>` —  Removes localization files except for the specified cultures (comma-separated list). (Recommended)
 
     _Affects_:
@@ -1181,6 +1191,8 @@ Check [toml syntax here](https://toml.io/en/v1.0.0).
 **Parameters:**
 
 - `apply.sorting = <true/false>` — Enable/disable sorting transform by default in [pkg apply](#pkg-apply) command.
+
+- `apply.sorting_comparer = <comparer>` — Configures sorting transform comparer by default in [pkg apply](#pkg-apply) command.
 
 - `apply.localization_cleanup = <except-localizations>` — Enable/disable localization cleanup transform by default in [pkg apply](#pkg-apply) command.
 

--- a/src/crtcli/src/cmd/app/fs/mod.rs
+++ b/src/crtcli/src/cmd/app/fs/mod.rs
@@ -61,7 +61,8 @@ fn print_fs_sync_result(result: &FileSystemSynchronizationResultResponse) {
                     .cmp(&i2.object_type.get_fs_order_index())
                     .then(
                         i1.name
-                            .cmp(&i2.name)
+                            .to_lowercase()
+                            .cmp(&i2.name.to_lowercase())
                             .then(i1.culture_name.cmp(&i2.culture_name)),
                     )
             });

--- a/src/crtcli/src/cmd/pkg/apply.rs
+++ b/src/crtcli/src/cmd/pkg/apply.rs
@@ -42,6 +42,15 @@ pub struct PkgApplyFeatures {
     #[serde(rename = "sorting")]
     apply_sorting: Option<bool>,
 
+    /// Configures sorting comparer for `--apply-sorting | -S` transform which will be used to sort strings.
+    #[arg(
+        long,
+        default_value = "alnum",
+        value_name = "COMPARER", 
+        value_hint = clap::ValueHint::Other)]
+    #[serde(rename = "sorting_comparer")]
+    apply_sorting_comparer: Option<SortingComparer>,
+
     /// Removes localization files except for the specified cultures (comma-separated list).
     /// Example: --apply-localization-cleanup "en-US,uk-UA"
     #[arg(
@@ -65,6 +74,9 @@ impl PkgApplyFeatures {
             apply_sorting: self
                 .apply_sorting
                 .or(other.as_ref().and_then(|x| x.apply_sorting)),
+            apply_sorting_comparer: self
+                .apply_sorting_comparer
+                .or(other.as_ref().and_then(|x| x.apply_sorting_comparer)),
             apply_localization_cleanup: self.apply_localization_cleanup.clone().or(other
                 .as_ref()
                 .and_then(|x| x.apply_localization_cleanup.clone())),
@@ -84,7 +96,9 @@ impl PkgApplyFeatures {
         }
 
         if self.apply_sorting.is_some_and(|x| x) {
-            combined.add(SortingPkgFileConverter);
+            combined.add(SortingPkgFileConverter::new(
+                self.apply_sorting_comparer.unwrap_or_default(),
+            ));
         }
 
         if let Some(bom_normalization) = self.apply_bom_normalization {

--- a/src/crtcli/src/utils/lexical_str.rs
+++ b/src/crtcli/src/utils/lexical_str.rs
@@ -1,0 +1,29 @@
+use std::cmp::Ordering;
+
+pub fn iterate_ascii_only_alnum(s: &'_ [u8]) -> impl DoubleEndedIterator<Item = char> + '_ {
+    s.iter().flat_map(|x| {
+        if x.is_ascii_alphanumeric() {
+            Some(*x as char)
+        } else {
+            None
+        }
+    })
+}
+
+pub fn ascii_alnum_cmp(s1: &[u8], s2: &[u8]) -> Ordering {
+    let mut iter1 = iterate_ascii_only_alnum(s1);
+    let mut iter2 = iterate_ascii_only_alnum(s2);
+
+    loop {
+        match (iter1.next(), iter2.next()) {
+            (Some(lhs), Some(rhs)) => {
+                if lhs != rhs {
+                    return lhs.cmp(&rhs);
+                }
+            }
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            _ => return s1.cmp(s2),
+        }
+    }
+}

--- a/src/crtcli/src/utils/mod.rs
+++ b/src/crtcli/src/utils/mod.rs
@@ -1,4 +1,7 @@
 pub mod bom;
 
 mod json_msdate_preserve_formatter;
+
+pub mod lexical_str;
+
 pub use json_msdate_preserve_formatter::*;


### PR DESCRIPTION
This PR redefines the sorting transform for package Resources (`Resources/**/resource.*.xml`).

In the previous implementation, sorting was done using a standard string comparer, byte by byte.

However, when resources are unloaded from the database to a file, Creatio uses database string sorting (`ORDER BY ... ASC`), and database sorting mechanisms can differ. For example, PostgreSQL uses collation, which results in the comparison logic ignoring non-alphanumeric characters when comparing strings. Microsoft SQL Server (MSSQL), in this case, does not.

Consequently, in a real-world scenario, if you work with a package in Creatio using PostgreSQL and then work with the same package in Creatio using MSSQL, your resource sorting will constantly change when switching between environments. This PR introduces a feature to `crtcli` to help standardize this sorting behavior.

The current implementation introduces a new transform option to the `pkg apply` command that allows configuring the string comparer:

```bash
--apply-sorting-comparer <COMPARER>
```

#### Possible Values:

  * **`alnum`** (aliases: `psql`, `postgresql`) (default) — An alphanumeric comparer designed to be equivalent to PostgreSQL's collation-based comparing/ordering. This means it ignores non-alphanumeric characters during comparison. This option is recommended when your primary Creatio database is PostgreSQL.
  * **`std`** (aliases: `standard`, `mssql`) — A standard comparer that uses all characters in a string and compares byte by byte. This option is recommended when your primary Creatio database is Microsoft SQL Server.

-----

### Sample

**Input Data:**

```
Supplier.Caption
StartDate.Caption
SupplierBillingInfo.Caption
SupplierPaymentInfo.Caption
```

**`--apply-sorting-comparer alnum` result:**
*(Non-alphanumeric characters like '.' are ignored, leading to an alphanumeric sort)*

```
StartDate.Caption
SupplierBillingInfo.Caption
Supplier.Caption
SupplierPaymentInfo.Caption
```

**`--apply-sorting-comparer std` result:**
*(All characters, including '.', are considered for byte-by-byte comparison)*

```
StartDate.Caption
Supplier.Caption
SupplierBillingInfo.Caption
SupplierPaymentInfo.Caption
```