### PR TITLE
feat(app pkg pull): add --on-missing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 
- - `--on-missing <fail|ignore|remove>` option for `app pkg pull` to control behavior when requested packages are missing from the remote Creatio instance
+ - Chunked package upload support by default for the `app pkg install` and `app pkg push` commands ([#40](https://github.com/heabijay/crtcli/pull/40))
 
- - Chunked package upload support for the `app pkg install` and `app pkg push` commands ([#40](https://github.com/heabijay/crtcli/pull/40))
+ - `--on-missing <fail|ignore|remove>` option for `app pkg pull` to control behavior when requested packages are missing from the remote Creatio instance ([#41](https://github.com/heabijay/crtcli/pull/41))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # crtcli Changelog
 
+## [Unreleased]
+
+### Added
+
+ - `--on-missing <fail|ignore|remove>` option for `app pkg pull` to control behavior when requested packages are missing from the remote Creatio instance
+
+
 ## [0.3.0](https://github.com/heabijay/crtcli/releases/tag/v0.3.0) (2025-12-01)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
  - `--on-missing <fail|ignore|remove>` option for `app pkg pull` to control behavior when requested packages are missing from the remote Creatio instance
 
+ - Chunked package upload support for the `app pkg install` and `app pkg push` commands ([#40](https://github.com/heabijay/crtcli/pull/40))
+
+### Changed
+
+ - The `app pkg pull` command now defaults to a folder named after the package if no destination is specified ([#39](https://github.com/heabijay/crtcli/pull/39))
+
+### Fixed
+
+ - Fixed an issue where the `--compile` option in the `app pkg install` command would compile the current directory instead of the packages specified as arguments
+
 
 ## [0.3.0](https://github.com/heabijay/crtcli/releases/tag/v0.3.0) (2025-12-01)
 

--- a/README.md
+++ b/README.md
@@ -626,6 +626,15 @@ but faster due to in memory processing, merging only changes and more feature-ri
 
 **Options:**
 
+- `--on-missing <MODE>` — Defines behavior when requested packages are missing from the remote Creatio instance.
+
+  Possible values:
+  - `fail` (default) — Fails the pull when any requested package cannot be found.
+  - `ignore` — Continues pulling the packages that are available and leaves destination folders for missing packages untouched.
+  - `remove` — Continues pulling the packages that are available and removes the contents of destination folders whose packages were missing. Check [pkg pack](#pkg-pack) command for package paths.
+
+  Defaults: fail
+
 - `--smart-merge` — Enables smart merge strategies that ignore insignificant differences caused by downloading packages from different Creatio instances.
 
   This option helps improve package version control diffs when working with Creatio without File System Development (FSD) mode.
@@ -660,6 +669,10 @@ For example current folder is '/Creatio_8.1.5.2176/Terrasoft.Configuration/Pkg/U
 - `crtcli app pkg pull UsrPackage3:/repos/Pkg3 UsrPackage2:/repos/Pkg2` — Downloads the 'UsrPackage3' and 'UsrPackage2' packages from the default Creatio instance and unpacks them into the '/repos/Pkg3' and '/repos/Pkg2' folders, respectively, merging with default transforms applied. Check [app](#app) command to configure default Creatio instance.
 
 - `crtcli app pkg pull :/repos/Pkg3` — Downloads the 'UsrPackage3' package (inferred from the destination folder) from the default Creatio instance and unpacks it into the '/repos/Pkg3' folder, merging with default transforms applied. Check [app](#app) command to configure default Creatio instance.
+
+- `crtcli app pkg pull --on-missing ignore` — Pulls the available packages and leaves destination folders for missing packages untouched so the command still succeeds.
+
+- `crtcli app pkg pull --on-missing remove` — Pulls the available packages and removes the contents of destination folders whose packages were missing on the remote.
 
 
 ### app pkg push

--- a/README.md
+++ b/README.md
@@ -626,15 +626,6 @@ but faster due to in memory processing, merging only changes and more feature-ri
 
 **Options:**
 
-- `--on-missing <MODE>` — Defines behavior when requested packages are missing from the remote Creatio instance.
-
-  Possible values:
-  - `fail` (default) — Fails the pull when any requested package cannot be found.
-  - `ignore` — Continues pulling the packages that are available and leaves destination folders for missing packages untouched.
-  - `remove` — Continues pulling the packages that are available and removes the contents of destination folders whose packages were missing. Check [pkg pack](#pkg-pack) command for package paths.
-
-  Defaults: fail
-
 - `--smart-merge` — Enables smart merge strategies that ignore insignificant differences caused by downloading packages from different Creatio instances.
 
   This option helps improve package version control diffs when working with Creatio without File System Development (FSD) mode.
@@ -649,6 +640,15 @@ but faster due to in memory processing, merging only changes and more feature-ri
   - _Schemas/**/*.cs_ (Missing file equals to an empty file)
 
   \* Same functionality as the `--smart-merge` option in the [pkg unpack](#pkg-unpack) command.
+
+- `--on-missing <MODE>` — Defines behavior when requested packages are missing from the remote Creatio instance.
+
+  Possible values:
+  - `fail` (default) — Fails the pull when any requested package cannot be found.
+  - `ignore` — Continues pulling the packages that are available and leaves destination folders for missing packages untouched.
+  - `remove` — Continues pulling the packages that are available and removes the contents of destination folders whose packages were missing. Check [pkg pack](#pkg-pack) command for package paths.
+
+  Defaults: fail
 
 And here you can use transforms from [pkg apply](#pkg-apply) command.
 

--- a/src/crtcli/src/cmd/app/pkg/pull_pkg.rs
+++ b/src/crtcli/src/cmd/app/pkg/pull_pkg.rs
@@ -1,3 +1,4 @@
+use crate::CommandHandledError;
 use crate::app::{CrtClient, CrtClientError};
 use crate::cfg::package::combine_apply_config_from_args_and_config;
 use crate::cfg::{PkgConfig, WorkspaceConfig};
@@ -13,9 +14,11 @@ use anstyle::{AnsiColor, Color, Style};
 use clap::Args;
 use clap::builder::{ValueParser, ValueParserFactory};
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
+use zip::result::ZipError;
 
 #[derive(Args, Debug)]
 pub struct PullPkgCommand {
@@ -34,6 +37,11 @@ pub struct PullPkgCommand {
     /// Enables smart merge strategies that ignore insignificant differences (check docs for more info)
     #[arg(long)]
     smart_merge: bool,
+
+    /// Defines what to do if some requested packages are missing in remote Creatio instance
+    /// (`fail` - exit with error, `ignore` - skip missing (keep local package content untouched), `remove` - skip and remove local package content)
+    #[arg(long, value_name = "MODE", default_value = "fail")]
+    on_missing: PkgMissingBehavior,
 
     #[command(flatten)]
     apply_features: Option<crate::pkg::transforms::PkgApplyFeatures>,
@@ -217,15 +225,35 @@ impl AppCommand for PullPkgCommand {
                     FilesAlreadyExistsInFolderStrategy::Merge
                 })
                 .print_merge_log(true)
-                .with_transform(apply_config.apply().build_combined_transform());
+                .with_transform(apply_config.apply().build_combined_transform())
+                .with_pkg_missing_behavior(self.on_missing);
 
-            extract_single_zip_package_to_folder(
+            let extract_result = extract_single_zip_package_to_folder(
                 std::io::Cursor::new(&package_data),
                 &package_map.destination_folder,
                 Some(&package_map.package_name),
                 &extract_config,
-            )
-            .map_err(PullPkgCommandError::ExtractPackage)?;
+            );
+
+            if let Err(ExtractSingleZipPackageError::GetGZipInZip {
+                source: ZipError::FileNotFound,
+                ..
+            }) = &extract_result
+            {
+                eprintln!(
+                    "{style}error: package was not found inside the zip archive{style:#}",
+                    style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red))),
+                );
+                eprintln!(
+                    "  {tip_style}tip:{tip_style:#} you can use {bold}--on-missing <ignore/remove>{bold:#} next time",
+                    tip_style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
+                    bold = Style::new().bold()
+                );
+
+                return Err(CommandHandledError(ExitCode::FAILURE).into());
+            }
+
+            extract_result.map_err(PullPkgCommandError::ExtractPackage)?;
 
             apply_config
                 .apply_post()

--- a/src/crtcli/src/pkg/bundling/extractor.rs
+++ b/src/crtcli/src/pkg/bundling/extractor.rs
@@ -3,8 +3,9 @@ use crate::pkg::bundling::utils::{
     FolderIsEmptyValidationError, remove_dir_all_files_predicate, validate_folder_is_empty,
 };
 use crate::pkg::transforms::*;
-use crate::pkg::utils::contains_hidden_path;
+use crate::pkg::utils::{contains_hidden_path, get_package_dir_entries};
 use anstyle::{AnsiColor, Color, Style};
+use clap::ValueEnum;
 use std::borrow::Cow;
 use std::cell::LazyCell;
 use std::collections::HashSet;
@@ -38,8 +39,8 @@ pub enum ExtractGzipPackageError {
     #[error("unable to create out folder or file {0}: {1}")]
     CreateFolderOrFile(PathBuf, #[source] std::io::Error),
 
-    #[error("failed to delete files during merge: {0}")]
-    DeleteFilesDuringMerge(#[source] std::io::Error),
+    #[error("failed to remove files during merge: {0}")]
+    RemoveFilesDuringMerge(#[source] std::io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -47,8 +48,13 @@ pub enum ExtractSingleZipPackageError {
     #[error("unable to open zip file for reading: {0}")]
     OpenZipFileForReading(#[source] ZipError),
 
-    #[error("unable to get gzip file in zip: {0}")]
-    GetGZipInZip(#[source] ZipError),
+    #[error("unable to get '{name}' gzip file in zip: {source}", name = .filename.as_deref().unwrap_or("any"))]
+    GetGZipInZip {
+        filename: Option<String>,
+
+        #[source]
+        source: ZipError,
+    },
 
     #[error(
         "multiple package in zip file was found when extracting single gzip package. Consider to specify package filename parameter or use extract_zip_package_to_folder method instead"
@@ -62,6 +68,9 @@ pub enum ExtractSingleZipPackageError {
         #[source]
         source: ExtractGzipPackageError,
     },
+
+    #[error("unable to remove files due missing package: {0}")]
+    RemoveFilesDueMissingPackage(#[source] std::io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -83,7 +92,7 @@ pub enum ExtractZipPackageError {
     },
 }
 
-#[derive(Default, Eq, PartialEq, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FilesAlreadyExistsInFolderStrategy {
     #[default]
     ThrowError,
@@ -91,10 +100,19 @@ pub enum FilesAlreadyExistsInFolderStrategy {
     SmartMerge,
 }
 
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum PkgMissingBehavior {
+    #[default]
+    Fail,
+    Ignore,
+    Remove,
+}
+
 #[derive(Default, Debug)]
 pub struct PackageToFolderExtractorConfig {
     files_already_exists_in_folder_strategy: FilesAlreadyExistsInFolderStrategy,
     file_transform: CombinedPkgFileTransform,
+    pkg_missing_behavior: PkgMissingBehavior,
     print_merge_log: bool,
 }
 
@@ -109,6 +127,11 @@ impl PackageToFolderExtractorConfig {
 
     pub fn with_transform(mut self, transform: CombinedPkgFileTransform) -> Self {
         self.file_transform = transform;
+        self
+    }
+
+    pub fn with_pkg_missing_behavior(mut self, behavior: PkgMissingBehavior) -> Self {
+        self.pkg_missing_behavior = behavior;
         self
     }
 
@@ -148,12 +171,7 @@ impl MergeContext {
         self,
         config: &PackageToFolderExtractorConfig,
     ) -> Result<(), std::io::Error> {
-        let pkg_folders = crate::pkg::paths::PKG_FOLDERS
-            .iter()
-            .map(|&p| self.destination_folder.join(p))
-            .filter(|p| p.exists());
-
-        for folder in pkg_folders {
+        for folder in get_package_dir_entries(&self.destination_folder) {
             remove_dir_all_files_predicate(&folder, |f| {
                 let path = f.path();
                 let relative_path = path.strip_prefix(&self.destination_folder).unwrap();
@@ -238,10 +256,11 @@ pub fn extract_gzip_package_to_folder(
         }
     }
 
-    merge_ctx.map(|ctx| {
-        ctx.execute_remove(config)
-            .map_err(ExtractGzipPackageError::DeleteFilesDuringMerge)
-    });
+    if let Some(merge_ctx) = merge_ctx {
+        merge_ctx
+            .execute_remove(config)
+            .map_err(ExtractGzipPackageError::RemoveFilesDuringMerge)?;
+    }
 
     return Ok(());
 
@@ -335,17 +354,9 @@ pub fn extract_single_zip_package_to_folder(
     let mut zip =
         ZipArchive::new(zip_reader).map_err(ExtractSingleZipPackageError::OpenZipFileForReading)?;
 
-    let gzip = match package_name {
-        Some(package_name) => zip_get_file_by_package_name(&mut zip, package_name)
-            .map_err(ExtractSingleZipPackageError::GetGZipInZip)?,
-        None => {
-            if zip.len() > 1 {
-                return Err(ExtractSingleZipPackageError::MultiplePackageInZipFile);
-            }
-
-            zip.by_index(0)
-                .map_err(ExtractSingleZipPackageError::GetGZipInZip)?
-        }
+    let gzip = determinate_gzip_file(&mut zip, package_name);
+    let Some(gzip) = handle_pkg_missing_behavior(gzip, destination_folder, config)? else {
+        return Ok(());
     };
 
     let gzip_filename = gzip.name().to_owned();
@@ -356,6 +367,73 @@ pub fn extract_single_zip_package_to_folder(
             source: err,
         }
     });
+
+    fn determinate_gzip_file<'a, R: Read + Seek>(
+        zip: &'a mut ZipArchive<R>,
+        package_name: Option<&str>,
+    ) -> Result<zip::read::ZipFile<'a, R>, ExtractSingleZipPackageError> {
+        if let Some(package_name) = package_name {
+            zip_get_file_by_package_name(zip, package_name).map_err(|err| {
+                ExtractSingleZipPackageError::GetGZipInZip {
+                    filename: Some(package_name.to_owned()),
+                    source: err,
+                }
+            })
+        } else if zip.len() > 1 {
+            Err(ExtractSingleZipPackageError::MultiplePackageInZipFile)
+        } else {
+            zip.by_index(0)
+                .map_err(|err| ExtractSingleZipPackageError::GetGZipInZip {
+                    filename: None,
+                    source: err,
+                })
+        }
+    }
+
+    fn handle_pkg_missing_behavior<'a, R: Read + Seek>(
+        result: Result<zip::read::ZipFile<'a, R>, ExtractSingleZipPackageError>,
+        destination_folder: &Path,
+        config: &PackageToFolderExtractorConfig,
+    ) -> Result<Option<zip::read::ZipFile<'a, R>>, ExtractSingleZipPackageError> {
+        match result {
+            Err(ExtractSingleZipPackageError::GetGZipInZip {
+                source: ZipError::FileNotFound,
+                filename,
+            }) => match config.pkg_missing_behavior {
+                PkgMissingBehavior::Remove => {
+                    eprintln!(
+                        "{style}warning: package was not found in zip, removing all package files in destination folder{style:#}",
+                        style = Style::new()
+                            .fg_color(Some(Color::Ansi(AnsiColor::BrightYellow)))
+                            .dimmed()
+                    );
+
+                    if let Some(merge_ctx) = MergeContext::new_if_needed(destination_folder, config)
+                    {
+                        merge_ctx
+                            .execute_remove(config)
+                            .map_err(ExtractSingleZipPackageError::RemoveFilesDueMissingPackage)?;
+                    }
+
+                    Ok(None)
+                }
+                PkgMissingBehavior::Ignore => {
+                    eprintln!(
+                        "{style}warning: package was not found in zip, destination folder remains unchanged{style:#}",
+                        style = Style::new()
+                            .fg_color(Some(Color::Ansi(AnsiColor::BrightYellow)))
+                            .dimmed()
+                    );
+                    Ok(None)
+                }
+                PkgMissingBehavior::Fail => Err(ExtractSingleZipPackageError::GetGZipInZip {
+                    filename,
+                    source: ZipError::FileNotFound,
+                }),
+            },
+            _ => Ok(Some(result?)),
+        }
+    }
 
     fn zip_get_file_by_package_name<'a, R: Read + Seek>(
         zip: &'a mut ZipArchive<R>,

--- a/src/crtcli/src/pkg/utils.rs
+++ b/src/crtcli/src/pkg/utils.rs
@@ -12,9 +12,7 @@ use walkdir::WalkDir;
 use zip::ZipArchive;
 use zip::unstable::LittleEndianReadExt;
 
-pub fn walk_over_package_dir(
-    pkg_folder: &Path,
-) -> impl Iterator<Item = walkdir::Result<walkdir::DirEntry>> + use<> {
+pub fn get_package_dir_entries(pkg_folder: &Path) -> impl Iterator<Item = PathBuf> + use<> {
     let valid_folders = paths::PKG_FOLDERS.map(|f| pkg_folder.join(f));
     let valid_files = [pkg_folder.join(paths::PKG_DESCRIPTOR_FILE)];
 
@@ -22,7 +20,12 @@ pub fn walk_over_package_dir(
         .into_iter()
         .chain(valid_folders)
         .filter(|x| x.exists())
-        .flat_map(|x| WalkDir::new(x).into_iter())
+}
+
+pub fn walk_over_package_dir(
+    pkg_folder: &Path,
+) -> impl Iterator<Item = walkdir::Result<walkdir::DirEntry>> + use<> {
+    get_package_dir_entries(pkg_folder).flat_map(|x| WalkDir::new(x).into_iter())
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This PR introduces the `--on-missing` option for the `app pkg pull` command, allowing you to control the behavior when requested packages are missing from the remote Creatio instance.

Previously, when pulling multiple packages (for example by using `workspace.crtcli.toml`), if any were missing on the remote, the command would fail with an error, stopping the entire operation.

Now for that case, you can use `--on-missing` option to handle missing packages:

*   **`fail` (default):** Maintains previous behavior by exiting with an error if a package is not found.
*   **`ignore`:** Skips missing packages and continues with others, leaving any existing local folders untouched.
*   **`remove`:** Skips missing packages but removes the local contents of their destination folders to stay in sync with the remote.

**Examples:**
- **Default (fail):** `crtcli app pkg pull MissingPkg` (Exits with error)
- **Ignore:** `crtcli app pkg pull Pkg1 MissingPkg --on-missing ignore` (Pulls Pkg1, skips MissingPkg)
- **Remove:** `crtcli app pkg pull Pkg1 MissingPkg --on-missing remove` (Pulls Pkg1, clears `./MissingPkg/` folder)
